### PR TITLE
Added LeaderBoard to Friends Page

### DIFF
--- a/Pages/friends.html
+++ b/Pages/friends.html
@@ -54,6 +54,26 @@
     <p>Track friends, compare rankings, and find players at your level</p>
   </div>
 
+  <h4 class="section-title">Leaderboard</h4>
+  <div class="card card-ui p-3">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Name</th>
+          <th>ELO</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>1</td><td>Charlie</td><td>1850</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+        <tr><td>2</td><td>Alice</td><td>1720</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+        <tr><td>3</td><td>John Doe</td><td>1650</td><td><button class="btn btn-sm btn-secondary">You</button></td></tr>
+        <tr><td>4</td><td>Bob</td><td>1600</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+      </tbody>
+    </table>
+  </div>
+
   <h4 class="section-title">Find Similar Skill Players</h4>
   <div class="card card-ui p-3">
     <input class="form-control mb-3" placeholder="Enter ELO range or name">


### PR DESCRIPTION
Added a leaderboard to the friend's page so that users can view their friends scores and statistics, and be able to see where they are ranking among others. This matches with our user story #2 of wanting to be able to view a leaderboard. 