### PR TITLE
Fix landing page CSS and branding

### DIFF
--- a/project/templates/landing.html
+++ b/project/templates/landing.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Chess Tracker</title>
+  <title>Chessmate</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='stylesheets/main.css')}}">
 </head>
 
 <body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
-      <a class="navbar-brand" href="#">Chess Tracker</a>
+      <a class="navbar-brand" href="#">Chessmate</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Updated CSS path from styles.css to stylesheets/main.css. Change brand name from 'Chess Tracker' to 'Chessmate' for consistency. Update page title to match application branding. Landing page now displays with proper styling.