### PR TITLE
Add dark/light mode

### DIFF
--- a/project/app/static/js/theme.js
+++ b/project/app/static/js/theme.js
@@ -1,0 +1,17 @@
+function toggleTheme() {
+  var html = document.documentElement;
+  var next = html.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+  html.setAttribute('data-bs-theme', next);
+  localStorage.setItem('chessmate-theme', next);
+  updateToggleButton(next);
+}
+
+function updateToggleButton(theme) {
+  var btn = document.getElementById('theme-toggle');
+  if (btn) btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  var theme = document.documentElement.getAttribute('data-bs-theme') || 'light';
+  updateToggleButton(theme);
+});

--- a/project/app/static/stylesheets/main.css
+++ b/project/app/static/stylesheets/main.css
@@ -104,3 +104,33 @@ body {
 .fc-event:hover {
     opacity: 0.8;
 }
+
+/* Dark mode overrides for custom components */
+[data-bs-theme="dark"] body {
+    background-color: #1a1d21;
+}
+
+[data-bs-theme="dark"] .hero,
+[data-bs-theme="dark"] .header,
+[data-bs-theme="dark"] .profile-header,
+[data-bs-theme="dark"] .calendar-header {
+    background-color: #2c3036;
+}
+
+[data-bs-theme="dark"] .graph-placeholder {
+    background-color: #2c3036;
+    border-color: #495057;
+    color: #adb5bd;
+}
+
+[data-bs-theme="dark"] .match-item {
+    background-color: #2c3036;
+}
+
+[data-bs-theme="dark"] .match-item:hover {
+    background-color: #343a40;
+}
+
+[data-bs-theme="dark"] .stat-item {
+    border-bottom-color: #495057;
+}

--- a/project/app/templates/calendar.html
+++ b/project/app/templates/calendar.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Tournament Calendar</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -33,6 +34,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link active" href="/calendar">Calendar</a>
+          </li>
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
           </li>
         </ul>
       </div>
@@ -111,6 +115,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       var calendarEl = document.getElementById('calendar');

--- a/project/app/templates/friends.html
+++ b/project/app/templates/friends.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Friends</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -28,6 +29,9 @@
           <a class="nav-link" href="/viewstats">Stats</a></li>
         <li class="nav-item">
           <a class="nav-link" href="/calendar">Calendar</a>
+        </li>
+        <li class="nav-item ms-2">
+          <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
         </li>
       </ul>
     </div>
@@ -118,6 +122,7 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 
 </body>
 </html>

--- a/project/app/templates/home.html
+++ b/project/app/templates/home.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Home</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -32,6 +33,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/calendar">Calendar</a>
+          </li>
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
           </li>
         </ul>
       </div>
@@ -66,6 +70,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 
 </body>
 </html>

--- a/project/app/templates/landing.html
+++ b/project/app/templates/landing.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Chessmate</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -23,6 +24,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/login">Log In</a>
+          </li>
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
           </li>
         </ul>
       </div>
@@ -57,6 +61,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 
 </body>
 </html>

--- a/project/app/templates/leaderboard.html
+++ b/project/app/templates/leaderboard.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Leaderboard - Chessmate</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -32,6 +33,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link active" href="{{ url_for('leaderboard') }}">Leaderboard</a>
+          </li>
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
           </li>
         </ul>
       </div>
@@ -97,6 +101,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script>
     const medals = { 1: '🥇', 2: '🥈', 3: '🥉' };
     document.querySelectorAll('.rank-cell').forEach(cell => {

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Profile Page</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -33,7 +34,9 @@
           <li class="nav-item">
             <a class="nav-link" href="/calendar">Calendar</a>
           </li>
-
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
+          </li>
         </ul>
       </div>
     </div>
@@ -118,6 +121,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 
 </body>
 </html>

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>(function(){var t=localStorage.getItem('chessmate-theme')||'light';document.documentElement.setAttribute('data-bs-theme',t);})();</script>
   <title>Stats - John Doe</title>
   
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -29,6 +30,9 @@
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/calendar">Calendar</a>
+          </li>
+          <li class="nav-item ms-2">
+            <button class="btn btn-sm btn-outline-light" id="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
           </li>
         </ul>
       </div>
@@ -117,5 +121,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Added a dark/light mode toggle button, for all main pages.

- Toggle saves preference to localStorage, so it stays across pages
- Uses Bootstrap 5.3's built-in dark mode support
- Custom CSS overrides