### PR TITLE
Fix leaderboard AttributeError by updating Match model references

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -270,11 +270,11 @@ def leaderboard():
     players = []
     for u in all_users:
         matches = Match.query.filter(
-            (Match.player1 == u.username) | (Match.player2 == u.username)
+            (Match.player == u.username) | (Match.opponent == u.username)
         ).all()
         wins = losses = draws = 0
         for m in matches:
-            if m.player1 == u.username:
+            if m.player == u.username:
                 if m.result == 'win': wins += 1
                 elif m.result == 'loss': losses += 1
                 else: draws += 1


### PR DESCRIPTION
Update leaderboard route to use correct Match model attributes. Change Match.player1 to Match.player and Match.player2 to Match.opponent. This fixes the AttributeError: type object 'Match' has no attribute 'player1'. Ensures leaderboard displays player statistics correctly with new database schema. 