### PR TITLE
Fix session loss on form submit, update latest match display, calendar and profile

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -8,8 +8,7 @@ from app import db
 from .blueprints import main
 from .models import User, Tournament, Match
 from .forgot_password import reset_password_email
-from datetime import date
-import datetime
+from datetime import date, datetime
 
 @main.context_processor
 def inject_profile_pic():
@@ -143,7 +142,7 @@ def profile():
     
     # Sort recent matches by date (most recent first) and take last 3
     recent_matches = sorted(recent_matches, 
-                          key=lambda x: next((m.date_played for m in user_matches), datetime.datetime.min), 
+                          key=lambda x: next((m.date_played for m in user_matches), datetime.min),
                           reverse=True)[:3]
     
     total_games = wins + losses + draws
@@ -235,7 +234,55 @@ def viewstats():
     if 'username' not in session:
         flash('Please log in to access this page!', 'error')
         return redirect(url_for('main.login'))
-    return render_template('viewstats.html', username=session['username'])
+
+    username = session['username']
+    user = User.query.filter_by(username=username).first()
+
+    user_matches = Match.query.filter(
+        (Match.player == username) | (Match.opponent == username)
+    ).all()
+
+    wins = losses = draws = 0
+    for m in user_matches:
+        r = (m.result or '').lower()
+        if m.player == username:
+            if r == 'win': wins += 1
+            elif r == 'loss': losses += 1
+            elif r == 'draw': draws += 1
+        else:
+            if r == 'loss': wins += 1
+            elif r == 'win': losses += 1
+            elif r == 'draw': draws += 1
+
+    total = wins + losses + draws
+    win_rate = round((wins / total * 100) if total > 0 else 0, 1)
+
+    # Compute simple ranking based on wins across all users
+    all_users = User.query.all()
+    rankings = []
+    for u in all_users:
+        u_matches = Match.query.filter(
+            (Match.player == u.username) | (Match.opponent == u.username)
+        ).all()
+        u_wins = 0
+        for m in u_matches:
+            r = (m.result or '').lower()
+            if m.player == u.username and r == 'win':
+                u_wins += 1
+            elif m.opponent == u.username and r == 'loss':
+                u_wins += 1
+        rankings.append((u.username, u_wins))
+    rankings.sort(key=lambda x: x[1], reverse=True)
+    user_rank = next((i + 1 for i, (u, _) in enumerate(rankings) if u == username), len(rankings) or 1)
+
+    stats = {
+        'wins': wins,
+        'losses': losses,
+        'draws': draws,
+        'win_rate': win_rate,
+        'ranking': f'#{user_rank}',
+    }
+    return render_template('viewstats.html', username=username, user=user, stats=stats)
 
 @main.route('/calendar')
 def calendar():
@@ -243,36 +290,48 @@ def calendar():
         flash('Please log in to access this page!', 'error')
         return redirect(url_for('main.login'))
     try:
-        # Get all matches (both with and without tournaments)
-        all_matches = Match.query.order_by(Match.date_played.desc()).all()
-        
-        # Format events for FullCalendar
+        username = session['username']
+        # Only show the current user's matches in the calendar
+        all_matches = Match.query.filter(
+            (Match.player == username) | (Match.opponent == username)
+        ).order_by(Match.date_played.desc()).all()
+
+        # Build display list with tournament info for the sidebar
+        match_entries = []
         events = []
         for match in all_matches:
+            result_lower = (match.result or '').lower()
             event_colour = '#6c757d'  # default gray for draw
-            if match.result.lower() == 'pending':
-                event_colour = '#ffc107'  # yellow for pending
-            elif match.result.lower() == 'win':
+            if result_lower == 'pending':
+                event_colour = '#ffc107'  # yellow for pending/upcoming
+            elif result_lower == 'win':
                 event_colour = '#28a745'  # green for win
-            elif match.result.lower() == 'loss':
+            elif result_lower == 'loss':
                 event_colour = '#dc3545'  # red for loss
-            
-            # Get tournament name if available
+
+            tournament = None
             tournament_name = ""
             if match.tournament_id:
                 tournament = Tournament.query.get(match.tournament_id)
                 if tournament:
                     tournament_name = f" - {tournament.name}"
-            
+
+            match_entries.append((match, tournament))
+
             events.append({
                 'title': f"{match.player} vs {match.opponent}{tournament_name}",
                 'start': match.date_played.isoformat(),
-                'backgroundcolour': event_colour,
-                'bordercolour': event_colour
+                'backgroundColor': event_colour,
+                'borderColor': event_colour,
+                'extendedProps': {
+                    'status': 'Upcoming' if result_lower == 'pending' else 'Completed',
+                    'result': (match.result or '').capitalize() or 'Unknown',
+                    'colour': (match.player_colour or '').capitalize()
+                }
             })
-        
-        return render_template('calendar.html', matches=all_matches, events=events, username=session['username'])
-    except Exception as e:
+
+        return render_template('calendar.html', matches=match_entries, events=events, username=username)
+    except Exception:
         # Handle case where tables don't exist or no data
         return render_template('calendar.html', matches=[], events=[], username=session['username'])
 

--- a/project/app/templates/calendar.html
+++ b/project/app/templates/calendar.html
@@ -24,21 +24,33 @@
     <div class="col-md-4">
       <div class="card card-ui mb-3">
         <div class="card-body">
-          <h5 class="card-title">Upcoming Matches</h5>
+          <h5 class="card-title">Your Matches</h5>
           <div class="upcoming-matches">
             {% for match, tournament in matches[:5] %}
+              {% set is_upcoming = (match.result or '')|lower == 'pending' %}
               <div class="match-item p-2 mb-2 border rounded">
                 <small class="text-muted">{{ match.date_played.strftime('%b %d, %Y') }}</small>
-                <div class="fw-bold">{{ tournament.name }}</div>
+                {% if tournament %}
+                  <div class="fw-bold">{{ tournament.name }}</div>
+                {% endif %}
                 <div>{{ match.player }} vs {{ match.opponent }}</div>
-                {% if match.result == 'pending' %}
-                  <span class="badge bg-warning">Pending</span>
-                {% elif match.result == 'win' %}
-                  <span class="badge bg-success">Win</span>
-                {% elif match.result == 'loss' %}
-                  <span class="badge bg-danger">Loss</span>
-                {% else %}
-                  <span class="badge bg-secondary">Draw</span>
+                <div class="mt-1">
+                  <small>Status:
+                    {% if is_upcoming %}
+                      <span class="badge bg-warning text-dark">Upcoming</span>
+                    {% else %}
+                      <span class="badge bg-success">Completed</span>
+                    {% endif %}
+                  </small>
+                </div>
+                {% if not is_upcoming %}
+                  {% if (match.result or '')|lower == 'win' %}
+                    <span class="badge bg-success">Win</span>
+                  {% elif (match.result or '')|lower == 'loss' %}
+                    <span class="badge bg-danger">Loss</span>
+                  {% else %}
+                    <span class="badge bg-secondary">Draw</span>
+                  {% endif %}
                 {% endif %}
               </div>
             {% endfor %}
@@ -58,16 +70,17 @@
               <span class="fw-bold">{{ matches|length }}</span>
             </div>
           </div>
+          {% set upcoming_count = matches|map(attribute=0)|selectattr('result', 'equalto', 'pending')|list|length %}
           <div class="stat-item mb-2">
             <div class="d-flex justify-content-between">
-              <span>Pending:</span>
-              <span class="fw-bold text-warning">{{ matches|selectattr('result', 'equalto', 'pending')|list|length }}</span>
+              <span>Upcoming:</span>
+              <span class="fw-bold text-warning">{{ upcoming_count }}</span>
             </div>
           </div>
           <div class="stat-item">
             <div class="d-flex justify-content-between">
               <span>Completed:</span>
-              <span class="fw-bold text-success">{{ matches|rejectattr('result', 'equalto', 'pending')|list|length }}</span>
+              <span class="fw-bold text-success">{{ matches|length - upcoming_count }}</span>
             </div>
           </div>
         </div>
@@ -92,7 +105,12 @@
       },
       events: eventsData,
       eventClick: function(info) {
-        alert('Match: ' + info.event.title + '\nDate: ' + info.event.start.toLocaleString());
+        var props = info.event.extendedProps || {};
+        var details = 'Match: ' + info.event.title + '\nDate: ' + info.event.start.toLocaleString();
+        if (props.status) details += '\nStatus: ' + props.status;
+        if (props.status !== 'Upcoming' && props.result) details += '\nResult: ' + props.result;
+        if (props.colour) details += '\nColour: ' + props.colour;
+        alert(details);
       }
     });
     calendar.render();

--- a/project/app/templates/friends.html
+++ b/project/app/templates/friends.html
@@ -23,7 +23,7 @@
       <tbody>
         <tr><td>1</td><td>Charlie</td><td>1850</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
         <tr><td>2</td><td>Alice</td><td>1720</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
-        <tr><td>3</td><td>John Doe</td><td>1650</td><td><button class="btn btn-sm btn-secondary">You</button></td></tr>
+        <tr><td>3</td><td>{{ username }}</td><td>1650</td><td><button class="btn btn-sm btn-secondary">You</button></td></tr>
         <tr><td>4</td><td>Bob</td><td>1600</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
       </tbody>
     </table>

--- a/project/app/templates/home.html
+++ b/project/app/templates/home.html
@@ -32,14 +32,26 @@
       <div class="card p-3">
         <h1>Latest match</h1>
         {% if latest_match %}
-          <div class="latest-match-info">
+          {% set is_upcoming = latest_match.result and latest_match.result.lower() == 'pending' %}
+          <div class="latest-match-info p-3 rounded" style="background-color: #2c2f33; color: #f8f9fa;">
             <p><strong>{{ latest_match.player }} vs {{ latest_match.opponent }}</strong></p>
-            <p>Result: <span class="badge bg-{{ 'success' if latest_match.result.lower() == 'win' else 'danger' if latest_match.result.lower() == 'loss' else 'secondary' }}">
-              {{ latest_match.result|capitalize }}
-            </span></p>
+            <p>Status:
+              {% if is_upcoming %}
+                <span class="badge bg-warning text-dark">Upcoming</span>
+              {% else %}
+                <span class="badge bg-success">Completed</span>
+              {% endif %}
+            </p>
+            {% if not is_upcoming %}
+              <p>Result: <span class="badge bg-{{ 'success' if latest_match.result.lower() == 'win' else 'danger' if latest_match.result.lower() == 'loss' else 'secondary' }}">
+                {{ latest_match.result|capitalize }}
+              </span></p>
+            {% endif %}
             <p>Color: {{ latest_match.player_colour|capitalize }}</p>
             <p>Date: {{ latest_match.date_played.strftime('%b %d, %Y') }}</p>
-            <p>Termination: {{ latest_match.termination|capitalize }}</p>
+            {% if latest_match.termination %}
+              <p class="mb-0">Termination: {{ latest_match.termination|capitalize }}</p>
+            {% endif %}
           </div>
         {% else %}
           <p>No matches recorded yet. <a href="{{ url_for('main.new_record') }}">Add your first match!</a></p>

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -28,6 +28,7 @@
     </div>
     <div>
       <h2>{{ user.username }}</h2>
+      <p class="mb-1 text-muted">{{ user.email }}</p>
       <p>Ranking: <strong>{{ stats.ranking }}</strong></p>
       <button class="btn btn-primary btn-custom" onclick="addFriend()">Add Friend</button>
       <button class="btn btn-success btn-custom" onclick="shareProfile()">Share Profile</button>

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -4,8 +4,8 @@
 {% block content %}
 <div class="container mt-5">
   <div class="profile-header">
-    <h2>John Doe</h2>
-    <p class="mb-0">Ranking: <strong>#3</strong></p>
+    <h2>{{ user.username if user else username }}</h2>
+    <p class="mb-0">Ranking: <strong>{{ stats.ranking }}</strong></p>
   </div>
 
   <h3 class="mt-5 mb-4">Statistics</h3>
@@ -35,25 +35,25 @@
     <div class="col-md-3">
       <div class="card stat-card p-3 text-center">
         <h5>Wins</h5>
-        <h3 class="text-success">25</h3>
+        <h3 class="text-success">{{ stats.wins }}</h3>
       </div>
     </div>
     <div class="col-md-3">
       <div class="card stat-card p-3 text-center">
         <h5>Losses</h5>
-        <h3 class="text-danger">10</h3>
+        <h3 class="text-danger">{{ stats.losses }}</h3>
       </div>
     </div>
     <div class="col-md-3">
       <div class="card stat-card p-3 text-center">
         <h5>Draws</h5>
-        <h3>5</h3>
+        <h3>{{ stats.draws }}</h3>
       </div>
     </div>
     <div class="col-md-3">
       <div class="card stat-card p-3 text-center">
         <h5>Win Rate</h5>
-        <h3>62%</h3>
+        <h3>{{ stats.win_rate }}%</h3>
       </div>
     </div>
   </div>

--- a/project/config.py
+++ b/project/config.py
@@ -5,7 +5,8 @@ default_db_path = 'sqlite:///' + os.path.join(basedir,"database","users.db")
 
 class Config: #Shared between Deployment & Development configs
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SECRET_KEY = os.urandom(24)
+    SECRET_KEY = os.getenv('SECRET_KEY') or 'chessmate-dev-secret-key-please-change-in-production'
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL') or default_db_path
 
 class DeploymentConfig(Config): # Used in real deployment
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL') or default_db_path


### PR DESCRIPTION
- Switched config to a stable key (env-overridable).
- Fixed routes.py import datetime by changing the import to from datetime import date, datetime and tidying the datetime.datetime.min reference.
- home.html now shows Status: Upcoming when result == 'pending', otherwise Status: Completed.
- Calendar route now filters to the logged-in user's matches, builds mathces and tournamets, tuples to match the template's loop, adds status / result / colour into extendedProps, and corrects the FullCalendar property names.
- Now shows status badges per match and the sidebar counts upcoming vs completed. Event clicks now surface status, result, and colour.
- viewstats route now computes real wins/losses/draws etc. from the database and passes user + stats, gets rid of placeholder.
- profile.html now also shows the user's email
- friends.html hardcoded name is now the username.