### PR TITLE
Friend, profile, and stat page update

### DIFF
--- a/project/app/static/stylesheets/main.css
+++ b/project/app/static/stylesheets/main.css
@@ -16,7 +16,7 @@ body {
 }
 
 .section-title {
-    margin-top: 40px;
+    margin-top: 15px;
     margin-bottom: 15px;
 }
 

--- a/project/app/templates/.footer.html
+++ b/project/app/templates/.footer.html
@@ -12,7 +12,7 @@
 </head>
 
 <footer>
-    <div class="footer">
+    <div class="footer mt-4">
         <div class="container">
             <div class="row align-items-center mt-3">
             <!--Short description-->

--- a/project/app/templates/friends.html
+++ b/project/app/templates/friends.html
@@ -6,72 +6,78 @@
 
   <div class="header text-center">
     <h2>Friends</h2>
-    <p>Track friends, compare rankings, and find players at your level</p>
+    <h5>Track friends, compare rankings, and find players at your level</h5>
+    <button class="btn btn-secondary btn-lg">Add friend</button><br>
   </div>
 
-  <h4 class="section-title">Leaderboard</h4>
-  <div class="card card-ui p-3">
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th>Rank</th>
-          <th>Name</th>
-          <th>ELO</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td>1</td><td>Charlie</td><td>1850</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
-        <tr><td>2</td><td>Alice</td><td>1720</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
-        <tr><td>3</td><td>{{ username }}</td><td>1650</td><td><button class="btn btn-sm btn-secondary">You</button></td></tr>
-        <tr><td>4</td><td>Bob</td><td>1600</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
-      </tbody>
-    </table>
-  </div>
+  <!--Tab headers-->
+  <ul class="nav nav-tabs mt-4" id="myTab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="friends-tab" data-bs-toggle="tab" data-bs-target="#friends" type="button" role="tab" aria-controls="friends" aria-selected="true">Friends</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="leaderboard-tab" data-bs-toggle="tab" data-bs-target="#leaderboard" type="button" role="tab" aria-controls="leaderboard" aria-selected="false">Leaderboard</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab" aria-controls="pending" aria-selected="false">Pending requests(?)</button>
+    </li>
+  </ul>
 
-  <h4 class="section-title">Find Similar Skill Players</h4>
-  <div class="card card-ui p-3">
-    <input class="form-control mb-3" placeholder="Enter ELO range or name">
-    <button class="btn btn-dark">Search</button>
-  </div>
-
-  <h4 class="section-title">Friends</h4>
-  <div class="row">
-    <div class="col-md-4">
-      <div class="card card-ui p-3 text-center">
-        <h5>Alice</h5>
-        <p>Ranking: #2</p>
-        <button class="btn btn-sm btn-primary">View Profile</button>
-        <button class="btn btn-sm btn-success mt-2">Share Win</button>
+  <!--Content of each tabs-->
+  <div class="tab-content" id="myTabContent">
+    <!--Friends tab-->
+    <div class="tab-pane fade show active" id="friends" role="tabpanel" aria-labelledby="friends-tab">
+        <div class="row mt-4">
+          <div class="col-md-4">
+            <div class="card card-ui p-3 text-center">
+              <h5>Alice</h5>
+              <p>Ranking: #2</p>
+              <button class="btn btn-sm btn-primary">View Profile</button>
+              <button class="btn btn-sm btn-success mt-2">Share Win</button>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="card card-ui p-3 text-center">
+              <h5>Bob</h5>
+              <p>Ranking: #4</p>
+              <button class="btn btn-sm btn-primary">View Profile</button>
+              <button class="btn btn-sm btn-success mt-2">Share Win</button>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="card card-ui p-3 text-center">
+              <h5>Charlie</h5>
+              <p>Ranking: #1</p>
+              <button class="btn btn-sm btn-primary">View Profile</button>
+              <button class="btn btn-sm btn-success mt-2">Share Win</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="col-md-4">
-      <div class="card card-ui p-3 text-center">
-        <h5>Bob</h5>
-        <p>Ranking: #4</p>
-        <button class="btn btn-sm btn-primary">View Profile</button>
-        <button class="btn btn-sm btn-success mt-2">Share Win</button>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card card-ui p-3 text-center">
-        <h5>Charlie</h5>
-        <p>Ranking: #1</p>
-        <button class="btn btn-sm btn-primary">View Profile</button>
-        <button class="btn btn-sm btn-success mt-2">Share Win</button>
-      </div>
-    </div>
-  </div>
 
-  <h4 class="section-title">Tournament Calendar</h4>
-  <div class="card card-ui p-3">
-    <ul class="list-group">
-      <li class="list-group-item">April 18 - Blitz Tournament</li>
-      <li class="list-group-item">April 22 - Ranked Matches</li>
-      <li class="list-group-item">April 28 - Weekly Championship</li>
-    </ul>
+    <!--Leaderboard tab-->
+    <div class="tab-pane fade" id="leaderboard" role="tabpanel" aria-labelledby="leaderboard-tab">
+      <div class="card card-ui p-3 mt-4">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th>Rank</th>
+              <th>Name</th>
+              <th>ELO</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>Charlie</td><td>1850</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+            <tr><td>2</td><td>Alice</td><td>1720</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+            <tr><td>3</td><td>{{ username }}</td><td>1650</td><td><button class="btn btn-sm btn-secondary">You</button></td></tr>
+            <tr><td>4</td><td>Bob</td><td>1600</td><td><button class="btn btn-sm btn-primary">View</button></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
-  
 </div>
 {% include '.footer.html' %}
 {% endblock %}

--- a/project/app/templates/home.html
+++ b/project/app/templates/home.html
@@ -87,7 +87,7 @@
       </div>
       
       <!-- Recent Activity -->
-      <div class="card p-3 mt-3">
+      <div class="card p-3 mt-4">
         <h4>Recent Activity</h4>
         {% if recent_matches %}
         <div class="recent-activity-scroll">

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -35,42 +35,6 @@
   </div>
 
   <div class="row mt-4">
-    <div class="col-md-3">
-      <div class="card stat-card p-3 text-center">
-        <h5>Wins</h5>
-        <h3>{{ stats.wins }}</h3>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card stat-card p-3 text-center">
-        <h5>Losses</h5>
-        <h3>{{ stats.losses }}</h3>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card stat-card p-3 text-center">
-        <h5>Draws</h5>
-        <h3>{{ stats.draws }}</h3>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card stat-card p-3 text-center">
-        <h5>Win Rate</h5>
-        <h3>{{ stats.win_rate }}%</h3>
-      </div>
-    </div>
-  </div>
-
-  <div class="row mt-4">
-    <div class="col-md-6">
-      <div class="card p-3">
-        <h5>Performance by Colour</h5>
-        <ul class="list-group">
-          <li class="list-group-item">White: {{ stats.white_win_rate }}% Win Rate</li>
-          <li class="list-group-item">Black: {{ stats.black_win_rate }}% Win Rate</li>
-        </ul>
-      </div>
-    </div>
     <div class="col-md-6">
       <div class="card p-3">
         <h5>Recent Matches</h5>
@@ -78,6 +42,15 @@
           {% for match in stats.recent_matches %}
           <li class="list-group-item">{{ match.result }} vs {{ match.opponent }}</li>
           {% endfor %}
+        </ul>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card p-3">
+        <h5>Performance by Colour</h5>
+        <ul class="list-group">
+          <li class="list-group-item">White: {{ stats.white_win_rate }}% Win Rate</li>
+          <li class="list-group-item">Black: {{ stats.black_win_rate }}% Win Rate</li>
         </ul>
       </div>
     </div>

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -29,7 +29,6 @@
     <div>
       <h2>{{ user.username }}</h2>
       <p class="mb-1 text-muted">{{ user.email }}</p>
-      <p>Ranking: <strong>{{ stats.ranking }}</strong></p>
       <!-- <button class="btn btn-primary btn-custom" onclick="addFriend()">Add Friend</button> -->
       <button class="btn btn-success btn-custom" onclick="shareProfile()">Share Profile</button>
     </div>
@@ -87,12 +86,6 @@
   <div class="card mt-4 p-3">
     <h5>Identified Weaknesses</h5>
     <p>{{ stats.weaknesses }}</p>
-  </div>
-
-  <div class="mt-4 mb-5">
-    <button class="btn btn-warning">View Full Stats</button>
-    <button class="btn btn-secondary">Find Similar Opponents</button>
-    <button class="btn btn-danger">Report Issue</button>
   </div>
 
 </div>

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -5,7 +5,8 @@
 <div class="container mt-5">
   <div class="profile-header">
     <h2>{{ user.username if user else username }}</h2>
-    <p class="mb-0">Ranking: <strong>{{ stats.ranking }}</strong></p>
+    <p class="mb-0">Ranking: <strong>{{stats.ranking }}</strong></p>
+    <p class="mb-0">ELO: <strong>{{stats.ELO}}</strong></p>
   </div>
 
   <div class="row mt-4">

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -8,29 +8,6 @@
     <p class="mb-0">Ranking: <strong>{{ stats.ranking }}</strong></p>
   </div>
 
-  <h3 class="mt-5 mb-4">Statistics</h3>
-
-  <div class="row">
-    <div class="col-lg-6 mb-4">
-      <div class="card stat-card p-4">
-        <h5>Last 30 Days ELO</h5>
-        <div class="graph-placeholder mt-3">
-          📈 Last 30 Days ELO Graph<br>
-          <small>(Line chart will go here)</small>
-        </div>
-      </div>
-    </div>
-    <div class="col-lg-6 mb-4">
-      <div class="card stat-card p-4">
-        <h5>All Time ELO</h5>
-        <div class="graph-placeholder mt-3">
-          📈 All Time ELO Graph<br>
-          <small>(Line chart will go here)</small>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="row mt-4">
     <div class="col-md-3">
       <div class="card stat-card p-3 text-center">
@@ -58,6 +35,27 @@
     </div>
   </div>
 
+  <div class="row mt-4">
+    <div class="col-lg-6 mb-4">
+      <div class="card stat-card p-4">
+        <h5>Last 30 Days ELO</h5>
+        <div class="graph-placeholder mt-3">
+          📈 Last 30 Days ELO Graph<br>
+          <small>(Line chart will go here)</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6 mb-4">
+      <div class="card stat-card p-4">
+        <h5>All Time ELO</h5>
+        <div class="graph-placeholder mt-3">
+          📈 All Time ELO Graph<br>
+          <small>(Line chart will go here)</small>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="card stat-card mt-5 p-4">
     <h5 class="mb-4">Advanced Metrics</h5>
     <div class="d-flex flex-wrap gap-3">
@@ -71,11 +69,10 @@
     <small class="text-muted mt-3 d-block">These buttons are not clickable yet</small>
   </div>
 
-  <div class="mt-5 mb-5">
+  <!-- <div class="mt-5 mb-5">
     <button class="btn btn-warning btn-custom">View Full Detailed Stats</button>
     <button class="btn btn-secondary btn-custom">Export Stats</button>
-    <button class="btn btn-danger btn-custom">Report Issue</button>
-  </div>
+  </div> -->
 </div>
 {% include '.footer.html' %}
 {% endblock %}


### PR DESCRIPTION
1. Made the "search friend" search bar a button on the top container that will link to another page, where users can find friends based on their search
2. Made the friends and leaderboard into separate pages in one navigation bar, adding other tabs are welcomed (for now, there is a pending request page with 0 content)
3. Deleted some unnecessary buttons at the bottom of some pages
4. Deleted the win/lose/draw/win rate from the profile page, as well as modified more of the layout
5. Added placeholder ELO stat on the stats page