### PR TITLE
UI improvements, leaderboard and calendar fixes, and DB migrations

### DIFF
--- a/project/app/models.py
+++ b/project/app/models.py
@@ -6,6 +6,7 @@ class User(db.Model):
     email = db.Column(db.String(100), unique=True, nullable=False)
     password_hash = db.Column(db.String(256), nullable=False)
     profile_pic = db.Column(db.String(200), nullable=True)
+    weaknesses = db.Column(db.Text, nullable=True)
 
 class Tournament(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 
-from app import db
+from app import db, csrf
 from .blueprints import main
 from .models import User, Tournament, Match, Friendship, Query
 from .forgot_password import reset_password_email
@@ -90,11 +90,11 @@ def home():
     total_games = wins + losses + draws
     win_rate = round((wins / total_games * 100) if total_games > 0 else 0, 1)
     
-    # Get recent activity (last 5 completed matches)
+    # Get recent activity (last 3 completed matches)
     recent_matches = Match.query.filter(
         (Match.player == username) | (Match.opponent == username),
         Match.result != 'pending'
-    ).order_by(Match.date_played.desc()).limit(5).all()
+    ).order_by(Match.date_played.desc()).limit(3).all()
     
     return render_template('home.html', 
                          username=username, 
@@ -207,9 +207,18 @@ def friends():
                 'elo': round(elo)
             })
     
-    return render_template('friends.html', username=current_user, players=players, 
-                         pending_requests=pending_requests, current_friends=current_friends)
+    # Build friends-only leaderboard (current user + accepted friends)
+    friend_usernames = {f['username'] for f in current_friends}
+    friend_usernames.add(current_user)
+    friends_leaderboard = [p for p in players if p['username'] in friend_usernames]
+    for i, p in enumerate(friends_leaderboard):
+        p['friends_rank'] = i + 1
 
+    return render_template('friends.html', username=current_user, players=players,
+                         pending_requests=pending_requests, current_friends=current_friends,
+                         friends_leaderboard=friends_leaderboard)
+
+@csrf.exempt
 @main.route('/add_friend', methods=['POST'])
 def add_friend():
     if 'username' not in session:
@@ -246,6 +255,7 @@ def add_friend():
     except Exception as e:
         return jsonify({'success': False, 'message': 'An error occurred. Please try again.'})
 
+@csrf.exempt
 @main.route('/send_friend_request', methods=['POST'])
 def send_friend_request():
     if 'username' not in session:
@@ -307,6 +317,7 @@ def send_friend_request():
     except Exception as e:
         return jsonify({'success': False, 'message': 'An error occurred. Please try again.'})
 
+@csrf.exempt
 @main.route('/respond_friend_request', methods=['POST'])
 def respond_friend_request():
     if 'username' not in session:
@@ -341,6 +352,7 @@ def respond_friend_request():
     except Exception as e:
         return jsonify({'success': False, 'message': 'An error occurred. Please try again.'})
 
+@csrf.exempt
 @main.route('/remove_friend', methods=['POST'])
 def remove_friend():
     if 'username' not in session:
@@ -640,8 +652,8 @@ def profile():
     if resignations > total_games * 0.4:
         weaknesses.append("Early resignations - develop endgame skills")
     
-    weaknesses_text = "; ".join(weaknesses) if weaknesses else "Keep practicing to identify areas for improvement!"
-    
+    computed_weaknesses = "; ".join(weaknesses) if weaknesses else "Keep practicing to identify areas for improvement!"
+
     user_stats = {
         'wins': wins,
         'losses': losses,
@@ -651,10 +663,29 @@ def profile():
         'black_win_rate': black_win_rate,
         'ranking': f'#{user_rank}',
         'recent_matches': recent_matches,
-        'weaknesses': weaknesses_text
+        # Use user-saved weaknesses if set, otherwise fall back to computed
+        'weaknesses': user.weaknesses if user.weaknesses else computed_weaknesses
     }
-    
+
     return render_template('profile.html', user=user, stats=user_stats, username=username)
+
+@main.route('/save_weaknesses', methods=['POST'])
+def save_weaknesses():
+    if 'username' not in session:
+        return redirect(url_for('main.login'))
+    user = User.query.filter_by(username=session['username']).first()
+    user.weaknesses = request.form.get('weaknesses', '').strip()
+    db.session.commit()
+    flash('Weaknesses saved!', 'success')
+    return redirect(url_for('main.profile'))
+
+@main.route('/lookup_user')
+def lookup_user():
+    username = request.args.get('username', '').strip()
+    if not username:
+        return jsonify({'found': False})
+    user = User.query.filter_by(username=username).first()
+    return jsonify({'found': bool(user)})
 
 @main.route('/viewstats')
 def viewstats():
@@ -973,21 +1004,24 @@ def leaderboard():
             if m.player == u.username:
                 if r == 'win': wins += 1
                 elif r == 'loss': losses += 1
-                else: draws += 1
+                elif r == 'draw': draws += 1
             else:
                 if r == 'loss': wins += 1
                 elif r == 'win': losses += 1
-                else: draws += 1
+                elif r == 'draw': draws += 1
         total = wins + losses + draws
+        win_rate = round((wins / total * 100) if total > 0 else 0, 1)
+        elo = 1200 + (wins * 10) + (win_rate * 2)
         players.append({
             'username': u.username,
             'wins': wins,
             'losses': losses,
             'draws': draws,
-            'win_rate': round((wins / total * 100) if total > 0 else 0, 1)
+            'win_rate': win_rate,
+            'elo': round(elo)
         })
 
-    players.sort(key=lambda x: (x['wins'], x['win_rate']), reverse=True)
+    players.sort(key=lambda x: x['elo'], reverse=True)
     return render_template('leaderboard.html', players=players, username=session['username'])
 
 @main.route('/h2h')

--- a/project/app/templates/calendar.html
+++ b/project/app/templates/calendar.html
@@ -28,6 +28,7 @@
           <div class="upcoming-matches">
             {% for match, tournament in matches[:5] %}
               {% set is_upcoming = (match.result or '')|lower == 'pending' %}
+              {% set r = (match.result or '')|lower %}
               <div class="match-item p-2 mb-2 border rounded">
                 <small class="text-muted">{{ match.date_played.strftime('%b %d, %Y') }}</small>
                 {% if tournament %}
@@ -35,29 +36,23 @@
                 {% endif %}
                 <div>{{ match.player }} vs {{ match.opponent }}</div>
                 <div class="mt-1">
-                  <small>Status:
-                    {% if is_upcoming %}
-                      <span class="badge bg-warning text-dark">Upcoming</span>
-                    {% else %}
-                      <span class="badge bg-success">Completed</span>
-                    {% endif %}
-                  </small>
-                </div>
-                {% if not is_upcoming %}
-                  {% if (match.result or '')|lower == 'win' %}
+                  {% if is_upcoming %}
+                    <span class="badge bg-warning text-dark">Upcoming</span>
+                  {% elif r == 'win' %}
                     <span class="badge bg-success">Win</span>
-                  {% elif (match.result or '')|lower == 'loss' %}
+                  {% elif r == 'loss' %}
                     <span class="badge bg-danger">Loss</span>
                   {% else %}
                     <span class="badge bg-secondary">Draw</span>
                   {% endif %}
-                {% endif %}
+                </div>
               </div>
             {% endfor %}
             {% if not matches %}
               <p class="text-muted">No matches scheduled yet.</p>
             {% endif %}
           </div>
+          <a href="{{ url_for('main.viewstats') }}" class="btn btn-sm btn-outline-primary mt-2">View all matches</a>
         </div>
       </div>
 

--- a/project/app/templates/edit_match.html
+++ b/project/app/templates/edit_match.html
@@ -27,8 +27,8 @@
         <div class="col-md-4">
           <label class="form-label" for="colour">Colour</label>
           <select class="form-select" id="colour" name="colour" required>
-            <option value="White" {% if match.player_colour == 'White' %}selected{% endif %}>White</option>
-            <option value="Black" {% if match.player_colour == 'Black' %}selected{% endif %}>Black</option>
+            <option value="white" {% if match.player_colour.lower() == 'white' %}selected{% endif %}>White</option>
+            <option value="black" {% if match.player_colour.lower() == 'black' %}selected{% endif %}>Black</option>
           </select>
         </div>
 

--- a/project/app/templates/friends.html
+++ b/project/app/templates/friends.html
@@ -81,37 +81,40 @@
     <!--Leaderboard tab-->
     <div class="tab-pane fade" id="leaderboard" role="tabpanel" aria-labelledby="leaderboard-tab">
       <div class="card card-ui p-3 mt-4">
-        <table class="table table-hover">
-          <thead>
-            <tr>
-              <th>Rank</th>
-              <th>Name</th>
-              <th>ELO</th>
-              <th>Win Rate</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for player in players %}
-            <tr>
-              <td>{{ player.rank }}</td>
-              <td>{{ player.username }}</td>
-              <td>{{ player.elo }}</td>
-              <td>{{ player.win_rate }}%</td>
-              <td>
-                {% if player.is_current_user %}
-                  <button class="btn btn-sm btn-secondary" disabled>You</button>
-                {% else %}
-                  <a href="{{ url_for('main.view_user', username=player.username) }}" class="btn btn-sm btn-primary">View</a>
-                {% endif %}
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-        {% if players|length == 0 %}
+        <p class="text-muted mb-2">Showing rankings among you and your friends.</p>
+        <div style="max-height: 340px; overflow-y: auto;">
+          <table class="table table-hover mb-0">
+            <thead style="position: sticky; top: 0; background: var(--bs-body-bg, #fff); z-index: 1;">
+              <tr>
+                <th>Rank</th>
+                <th>Name</th>
+                <th>ELO</th>
+                <th>Win Rate</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for player in friends_leaderboard %}
+              <tr {% if player.username == username %}class="table-active fw-bold"{% endif %}>
+                <td>{{ player.friends_rank }}</td>
+                <td>{{ player.username }}</td>
+                <td>{{ player.elo }}</td>
+                <td>{{ player.win_rate }}%</td>
+                <td>
+                  {% if player.username == username %}
+                    <button class="btn btn-sm btn-secondary" disabled>You</button>
+                  {% else %}
+                    <a href="{{ url_for('main.view_user', username=player.username) }}" class="btn btn-sm btn-primary">View</a>
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% if friends_leaderboard|length <= 1 %}
         <div class="text-center py-4">
-          <p class="text-muted">No players found in the system yet.</p>
+          <p class="text-muted">Add friends to see how you compare!</p>
         </div>
         {% endif %}
       </div>

--- a/project/app/templates/home.html
+++ b/project/app/templates/home.html
@@ -63,31 +63,8 @@
         {% endif %}
       </div>
       
-      <!-- Quick Stats -->
-      <div class="card p-3 mt-3">
-        <h4>Quick Stats</h4>
-        <div class="row text-center">
-          <div class="col-4">
-            <h5 class="text-success">{{ stats.wins }}</h5>
-            <small>Wins</small>
-          </div>
-          <div class="col-4">
-            <h5 class="text-danger">{{ stats.losses }}</h5>
-            <small>Losses</small>
-          </div>
-          <div class="col-4">
-            <h5 class="text-secondary">{{ stats.draws }}</h5>
-            <small>Draws</small>
-          </div>
-        </div>
-        <div class="text-center mt-2">
-          <h5>{{ stats.win_rate }}%</h5>
-          <small>Win Rate</small>
-        </div>
-      </div>
-      
       <!-- Recent Activity -->
-      <div class="card p-3 mt-4">
+      <div class="card p-3 mt-3">
         <h4>Recent Activity</h4>
         {% if recent_matches %}
         <div class="recent-activity-scroll">
@@ -107,6 +84,29 @@
         <p class="text-muted">No completed matches yet. Start playing and recording your games to see your recent activity here!</p>
         {% endif %}
         <a href="{{ url_for('main.viewstats') }}" class="btn btn-sm btn-outline-primary mt-2">View all matches</a>
+      </div>
+
+      <!-- Quick Stats -->
+      <div class="card p-3 mt-4">
+        <h4>Quick Stats</h4>
+        <div class="row text-center">
+          <div class="col-4">
+            <h5 class="text-success">{{ stats.wins }}</h5>
+            <small>Wins</small>
+          </div>
+          <div class="col-4">
+            <h5 class="text-danger">{{ stats.losses }}</h5>
+            <small>Losses</small>
+          </div>
+          <div class="col-4">
+            <h5 class="text-secondary">{{ stats.draws }}</h5>
+            <small>Draws</small>
+          </div>
+        </div>
+        <div class="text-center mt-2">
+          <h5>{{ stats.win_rate }}%</h5>
+          <small>Win Rate</small>
+        </div>
       </div>
     </div>
   </div>

--- a/project/app/templates/leaderboard.html
+++ b/project/app/templates/leaderboard.html
@@ -12,55 +12,57 @@
   <div class="row mt-4">
     <div class="col-12">
       <div class="card card-ui p-3">
-        <table class="table table-hover mb-0">
-          <thead>
-            <tr>
-              <th>Rank</th>
-              <th>Player</th>
-              <th>Wins</th>
-              <th>Losses</th>
-              <th>Draws</th>
-              <th>Win Rate</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for player in players %}
-            <tr {% if player.username == username %}class="table-active fw-bold"{% endif %}>
-              <td class="rank-cell" data-rank="{{ loop.index }}">#{{ loop.index }}</td>
-              <td>
-                {% if player.username != username %}
-                <a href="{{ url_for('main.h2h', opponent=player.username) }}" class="text-decoration-none">{{ player.username }}</a>
-                {% else %}
-                {{ player.username }}
-                {% endif %}
-              </td>
-              <td>{{ player.wins }}</td>
-              <td>{{ player.losses }}</td>
-              <td>{{ player.draws }}</td>
-              <td>{{ player.win_rate }}%</td>
-            </tr>
-            {% else %}
-            <tr>
-              <td class="rank-cell" data-rank="1">#1</td>
-              <td>Magnus Carlsen</td>
-              <td colspan="3" class="text-muted fst-italic">ELO: 2882</td>
-              <td>—</td>
-            </tr>
-            <tr>
-              <td class="rank-cell" data-rank="2">#2</td>
-              <td>Garry Kasparov</td>
-              <td colspan="3" class="text-muted fst-italic">ELO: 2851</td>
-              <td>—</td>
-            </tr>
-            <tr>
-              <td class="rank-cell" data-rank="3">#3</td>
-              <td>Bobby Fischer</td>
-              <td colspan="3" class="text-muted fst-italic">ELO: 2785</td>
-              <td>—</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+        <div style="max-height: 350px; overflow-y: auto;">
+          <table class="table table-hover mb-0">
+            <thead style="position: sticky; top: 0; background: var(--bs-body-bg, #fff); z-index: 1;">
+              <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>ELO</th>
+                <th>Wins</th>
+                <th>Losses</th>
+                <th>Draws</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for player in players %}
+              <tr {% if player.username == username %}class="table-active fw-bold"{% endif %}>
+                <td class="rank-cell" data-rank="{{ loop.index }}">#{{ loop.index }}</td>
+                <td>
+                  {% if player.username != username %}
+                  <a href="{{ url_for('main.h2h', opponent=player.username) }}" class="text-decoration-none">{{ player.username }}</a>
+                  {% else %}
+                  {{ player.username }}
+                  {% endif %}
+                </td>
+                <td>{{ player.elo }}</td>
+                <td>{{ player.wins }}</td>
+                <td>{{ player.losses }}</td>
+                <td>{{ player.draws }}</td>
+              </tr>
+              {% else %}
+              <tr>
+                <td class="rank-cell" data-rank="1">#1</td>
+                <td>Magnus Carlsen</td>
+                <td>2882</td>
+                <td colspan="3" class="text-muted fst-italic">—</td>
+              </tr>
+              <tr>
+                <td class="rank-cell" data-rank="2">#2</td>
+                <td>Garry Kasparov</td>
+                <td>2851</td>
+                <td colspan="3" class="text-muted fst-italic">—</td>
+              </tr>
+              <tr>
+                <td class="rank-cell" data-rank="3">#3</td>
+                <td>Bobby Fischer</td>
+                <td>2785</td>
+                <td colspan="3" class="text-muted fst-italic">—</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/project/app/templates/new_record.html
+++ b/project/app/templates/new_record.html
@@ -20,7 +20,8 @@
 
         <div class="col-md-4">
           <label class="form-label" for="opponent">Opponent</label>
-          <input class="form-control" id="opponent" name="opponent" required>
+          <input class="form-control" id="opponent" name="opponent" required autocomplete="off">
+          <div id="opponent-status" class="form-text"></div>
         </div>
 
         <div class="col-md-4" id="result_field">
@@ -38,8 +39,8 @@
           <label class="form-label" for="colour">Colour</label>
           <select class="form-select" id="colour" name="colour" required>
             <option value="">Select colour</option>
-            <option value="White">White</option>
-            <option value="Black">Black</option>
+            <option value="white">White</option>
+            <option value="black">Black</option>
           </select>
         </div>
 
@@ -176,6 +177,30 @@ function toggleMatchFields() {
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', function() {
   toggleMatchFields();
+
+  // Opponent ChessMate lookup
+  const opponentInput = document.getElementById('opponent');
+  const statusEl = document.getElementById('opponent-status');
+  let lookupTimer = null;
+
+  opponentInput.addEventListener('input', function() {
+    clearTimeout(lookupTimer);
+    const val = opponentInput.value.trim();
+    if (!val) { statusEl.textContent = ''; return; }
+    lookupTimer = setTimeout(function() {
+      fetch('/lookup_user?username=' + encodeURIComponent(val))
+        .then(r => r.json())
+        .then(data => {
+          if (data.found) {
+            statusEl.innerHTML = '✓ Found on ChessMate — their stats will update automatically';
+            statusEl.className = 'form-text text-success';
+          } else {
+            statusEl.textContent = 'Not on ChessMate — will be recorded as external player';
+            statusEl.className = 'form-text text-muted';
+          }
+        });
+    }, 400);
+  });
 });
 </script>
 {% endblock %}

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -44,6 +44,7 @@
           <li class="list-group-item">{{ match.result }} vs {{ match.opponent }}</li>
           {% endfor %}
         </ul>
+        <a href="{{ url_for('main.viewstats') }}" class="btn btn-sm btn-outline-primary mt-2">View all matches</a>
       </div>
     </div>
     <div class="col-md-6">
@@ -59,7 +60,11 @@
 
   <div class="card mt-4 p-3">
     <h5>Identified Weaknesses</h5>
-    <p>{{ stats.weaknesses }}</p>
+    <form method="POST" action="{{ url_for('main.save_weaknesses') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <textarea class="form-control mb-2" name="weaknesses" rows="3" placeholder="Enter your identified weaknesses...">{{ stats.weaknesses }}</textarea>
+      <button type="submit" class="btn btn-sm btn-primary">Save</button>
+    </form>
   </div>
 
 </div>

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -81,48 +81,50 @@
       <a href="{{ url_for('main.new_record') }}" class="btn btn-primary btn-sm btn-custom">+ Add Match</a>
     </div>
     {% if matches %}
-    <table class="table table-hover mb-0">
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th>Opponent</th>
-          <th>Colour</th>
-          <th>Result</th>
-          <th>Termination</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for m in matches %}
-        <tr>
-          <td>{{ m.date_played.strftime('%Y-%m-%d') if m.date_played else '—' }}</td>
-          <td>{{ m.opponent }}</td>
-          <td class="text-capitalize">{{ m.player_colour }}</td>
-          <td>
-            {% set r = (m.result or '') | lower %}
-            {% if r == 'win' %}
-              <span class="badge bg-success">Win</span>
-            {% elif r == 'loss' %}
-              <span class="badge bg-danger">Loss</span>
-            {% elif r == 'draw' %}
-              <span class="badge bg-secondary">Draw</span>
-            {% else %}
-              <span class="badge bg-warning text-dark">Pending</span>
-            {% endif %}
-          </td>
-          <td class="text-capitalize">{{ m.termination or '—' }}</td>
-          <td class="text-end">
-            <a href="https://lichess.org/analysis/pgn/{{ m.moves }}" target="_blank"class="btn btn-sm btn-outline-info me-1">View</a>
-            <a href="{{ url_for('main.edit_match', match_id=m.id) }}" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
-            <form method="POST" action="{{ url_for('main.delete_match', match_id=m.id) }}" class="d-inline"
-                  onsubmit="return confirm('Delete this match?')">
-              <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
-            </form>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div style="max-height: 280px; overflow-y: auto;">
+      <table class="table table-hover mb-0">
+        <thead style="position: sticky; top: 0; background: var(--bs-body-bg, #fff); z-index: 1;">
+          <tr>
+            <th>Date</th>
+            <th>Opponent</th>
+            <th>Colour</th>
+            <th>Result</th>
+            <th>Termination</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for m in matches %}
+          <tr>
+            <td>{{ m.date_played.strftime('%Y-%m-%d') if m.date_played else '—' }}</td>
+            <td>{{ m.opponent }}</td>
+            <td class="text-capitalize">{{ m.player_colour }}</td>
+            <td>
+              {% set r = (m.result or '') | lower %}
+              {% if r == 'win' %}
+                <span class="badge bg-success">Win</span>
+              {% elif r == 'loss' %}
+                <span class="badge bg-danger">Loss</span>
+              {% elif r == 'draw' %}
+                <span class="badge bg-secondary">Draw</span>
+              {% else %}
+                <span class="badge bg-warning text-dark">Pending</span>
+              {% endif %}
+            </td>
+            <td class="text-capitalize">{{ m.termination or '—' }}</td>
+            <td class="text-end">
+              <a href="https://lichess.org/analysis/pgn/{{ m.moves }}" target="_blank" class="btn btn-sm btn-outline-info me-1">View</a>
+              <a href="{{ url_for('main.edit_match', match_id=m.id) }}" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
+              <form method="POST" action="{{ url_for('main.delete_match', match_id=m.id) }}" class="d-inline"
+                    onsubmit="return confirm('Delete this match?')">
+                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
     {% else %}
     <p class="text-muted mb-0">No matches recorded yet. <a href="{{ url_for('main.new_record') }}">Add one!</a></p>
     {% endif %}

--- a/project/migrations/versions/a2b3c4d5e6f7_add_weaknesses_to_user.py
+++ b/project/migrations/versions/a2b3c4d5e6f7_add_weaknesses_to_user.py
@@ -1,0 +1,26 @@
+"""Add weaknesses to user
+
+Revision ID: a2b3c4d5e6f7
+Revises: 115ee77446c6
+Create Date: 2026-05-14 18:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a2b3c4d5e6f7'
+down_revision = '115ee77446c6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('weaknesses', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('weaknesses')

--- a/project/migrations/versions/b3c4d5e6f7a8_drop_player1_color_columns.py
+++ b/project/migrations/versions/b3c4d5e6f7a8_drop_player1_color_columns.py
@@ -1,0 +1,28 @@
+"""Drop unused player1_color and player2_color columns from match
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-05-14 18:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b3c4d5e6f7a8'
+down_revision = 'a2b3c4d5e6f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('match', schema=None) as batch_op:
+        batch_op.drop_column('player1_color')
+        batch_op.drop_column('player2_color')
+
+
+def downgrade():
+    with op.batch_alter_table('match', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('player1_color', sa.String(length=5), nullable=True))
+        batch_op.add_column(sa.Column('player2_color', sa.String(length=5), nullable=True))


### PR DESCRIPTION
Home page: Swapped Recent Activity and Quick Stats order. Limited recent matches to 3.
Profile: Identified weaknesses is now a user-editable text box (saved to DB). Add "View all matches" link under recent matches.
Friends: Fixed friendship table (CSRF exemption on all friend AJAX routes). Friends leaderboard now shows only friends + self, sorted by ELO.
Stats: Match history table is vertically scrollable (max 5 rows visible).
New Record: Opponent field live-checks if user is on ChessMate. Standardised colour values to lowercase.
Edit Match: Fixed colour dropdown not pre-selecting for mixed-case stored values.
Leaderboard: Fixed pending matches incorrectly counting as draws. Sorted by ELO instead of win rate. Vertically scrollable (7 rows).
Calendar: Sidebar shows correct result badges (draw = grey). Add "View all matches" link to stats page.
Migrations: a2b3c4d5e6f7 adds weaknesses column to user table. b3c4d5e6f7a8: drops player1_color and player2_color columns from match table.