### PR TITLE
Correct perspective on calendar, stats, and profile for opponent-recorded matches

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -572,11 +572,14 @@ def profile():
                 # Skip upcoming matches from stats calculation
                 continue
         
+        colour = match.player_colour if match.player == username else ('black' if match.player_colour.lower() == 'white' else 'white')
+
         # Add to recent matches
         recent_matches.append({
             'opponent': opponent,
             'result': user_result,
-            'date': match.date_played
+            'date': match.date_played,
+            'colour': colour.capitalize()
         })
     
     # Sort recent matches by date (most recent first) and take last 3
@@ -607,64 +610,58 @@ def profile():
     user_rankings.sort(key=lambda x: x[1], reverse=True)
     user_rank = next((i+1 for i, (u, _) in enumerate(user_rankings) if u == username), len(user_rankings))
     
-    # Calculate color-specific win rates
+    # Calculate colour-specific stats from the user's perspective
     white_wins = white_losses = white_draws = 0
     black_wins = black_losses = black_draws = 0
-    
+
     for match in user_matches:
-        if match.player_colour.lower() == 'white':
-            if match.result.lower() == 'win':
-                white_wins += 1
-            elif match.result.lower() == 'loss':
-                white_losses += 1
+        r = (match.result or '').lower()
+        if r == 'pending':
+            continue
+
+        if match.player == username:
+            colour = match.player_colour.lower()
+            result = r
+        else:
+            # Reverse colour and result when user is the opponent
+            colour = 'black' if match.player_colour.lower() == 'white' else 'white'
+            if r == 'win':
+                result = 'loss'
+            elif r == 'loss':
+                result = 'win'
             else:
-                white_draws += 1
-        else:  # black
-            if match.result.lower() == 'win':
-                black_wins += 1
-            elif match.result.lower() == 'loss':
-                black_losses += 1
-            else:
-                black_draws += 1
-    
+                result = 'draw'
+
+        if colour == 'white':
+            if result == 'win': white_wins += 1
+            elif result == 'loss': white_losses += 1
+            elif result == 'draw': white_draws += 1
+        else:
+            if result == 'win': black_wins += 1
+            elif result == 'loss': black_losses += 1
+            elif result == 'draw': black_draws += 1
+
     white_total = white_wins + white_losses + white_draws
     black_total = black_wins + black_losses + black_draws
     white_win_rate = round((white_wins / white_total * 100) if white_total > 0 else 0, 1)
     black_win_rate = round((black_wins / black_total * 100) if black_total > 0 else 0, 1)
     
-    # Analyze weaknesses based on performance data
-    weaknesses = []
-    if losses > wins * 1.5:
-        weaknesses.append("High loss rate - focus on defensive strategies")
-    if black_win_rate < white_win_rate - 10:
-        weaknesses.append("Struggles playing as black - study black opening strategies")
-    if white_win_rate < black_win_rate - 10:
-        weaknesses.append("Struggles playing as white - improve opening repertoire")
-    if total_games < 10:
-        weaknesses.append("Limited experience - play more games to improve")
-    
-    # Analyze termination patterns
-    timeouts = sum(1 for match in user_matches if match.termination and 'timeout' in match.termination.lower())
-    resignations = sum(1 for match in user_matches if match.termination and 'resign' in match.termination.lower())
-    
-    if timeouts > total_games * 0.3:
-        weaknesses.append("Frequent timeouts - improve time management")
-    if resignations > total_games * 0.4:
-        weaknesses.append("Early resignations - develop endgame skills")
-    
-    computed_weaknesses = "; ".join(weaknesses) if weaknesses else "Keep practicing to identify areas for improvement!"
-
     user_stats = {
         'wins': wins,
         'losses': losses,
         'draws': draws,
         'win_rate': win_rate,
+        'white_wins': white_wins,
+        'white_losses': white_losses,
+        'white_draws': white_draws,
         'white_win_rate': white_win_rate,
+        'black_wins': black_wins,
+        'black_losses': black_losses,
+        'black_draws': black_draws,
         'black_win_rate': black_win_rate,
         'ranking': f'#{user_rank}',
         'recent_matches': recent_matches,
-        # Use user-saved weaknesses if set, otherwise fall back to computed
-        'weaknesses': user.weaknesses if user.weaknesses else computed_weaknesses
+        'weaknesses': user.weaknesses or ''
     }
 
     return render_template('profile.html', user=user, stats=user_stats, username=username)
@@ -742,7 +739,9 @@ def viewstats():
         'ELO': 1200 + (wins * 10),
     }
 
-    my_matches = Match.query.filter_by(player=username).order_by(Match.date_played.desc()).all()
+    my_matches = Match.query.filter(
+        (Match.player == username) | (Match.opponent == username)
+    ).order_by(Match.date_played.desc()).all()
     return render_template('viewstats.html', username=username, user=user, stats=stats, matches=my_matches)
 
 @main.route('/calendar')
@@ -762,12 +761,21 @@ def calendar():
         events = []
         for match in all_matches:
             result_lower = (match.result or '').lower()
+
+            # Reverse result when user is the opponent, not the recording player
+            if match.opponent == username and result_lower == 'win':
+                user_result = 'loss'
+            elif match.opponent == username and result_lower == 'loss':
+                user_result = 'win'
+            else:
+                user_result = result_lower
+
             event_colour = '#6c757d'  # default gray for draw
-            if result_lower == 'pending':
+            if user_result == 'pending':
                 event_colour = '#ffc107'  # yellow for pending/upcoming
-            elif result_lower == 'win':
+            elif user_result == 'win':
                 event_colour = '#28a745'  # green for win
-            elif result_lower == 'loss':
+            elif user_result == 'loss':
                 event_colour = '#dc3545'  # red for loss
 
             tournament = None
@@ -779,14 +787,19 @@ def calendar():
 
             match_entries.append((match, tournament))
 
+            if match.player == username:
+                title = f"{match.player} vs {match.opponent}{tournament_name}"
+            else:
+                title = f"{match.opponent} vs {match.player}{tournament_name}"
+
             events.append({
-                'title': f"{match.player} vs {match.opponent}{tournament_name}",
+                'title': title,
                 'start': match.date_played.isoformat(),
                 'backgroundColor': event_colour,
                 'borderColor': event_colour,
                 'extendedProps': {
-                    'status': 'Upcoming' if result_lower == 'pending' else 'Completed',
-                    'result': (match.result or '').capitalize() or 'Unknown',
+                    'status': 'Upcoming' if user_result == 'pending' else 'Completed',
+                    'result': user_result.capitalize() or 'Unknown',
                     'colour': (match.player_colour or '').capitalize()
                 }
             })

--- a/project/app/templates/calendar.html
+++ b/project/app/templates/calendar.html
@@ -27,14 +27,17 @@
           <h5 class="card-title">Your Matches</h5>
           <div class="upcoming-matches">
             {% for match, tournament in matches[:5] %}
-              {% set is_upcoming = (match.result or '')|lower == 'pending' %}
-              {% set r = (match.result or '')|lower %}
+              {% set raw = (match.result or '')|lower %}
+              {% if match.opponent == username and raw == 'win' %}{% set r = 'loss' %}
+              {% elif match.opponent == username and raw == 'loss' %}{% set r = 'win' %}
+              {% else %}{% set r = raw %}{% endif %}
+              {% set is_upcoming = r == 'pending' %}
               <div class="match-item p-2 mb-2 border rounded">
                 <small class="text-muted">{{ match.date_played.strftime('%b %d, %Y') }}</small>
                 {% if tournament %}
                   <div class="fw-bold">{{ tournament.name }}</div>
                 {% endif %}
-                <div>{{ match.player }} vs {{ match.opponent }}</div>
+                <div>{{ username }} vs {{ match.opponent if match.player == username else match.player }}</div>
                 <div class="mt-1">
                   {% if is_upcoming %}
                     <span class="badge bg-warning text-dark">Upcoming</span>

--- a/project/app/templates/profile.html
+++ b/project/app/templates/profile.html
@@ -41,7 +41,14 @@
         <h5>Recent Matches</h5>
         <ul class="list-group">
           {% for match in stats.recent_matches %}
-          <li class="list-group-item">{{ match.result }} vs {{ match.opponent }}</li>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div>
+              <span class="badge bg-{{ 'success' if match.result == 'Win' else 'danger' if match.result == 'Loss' else 'secondary' }} me-2">{{ match.result }}</span>
+              vs {{ match.opponent }}
+              <br><small class="text-muted">{{ match.colour }}</small>
+            </div>
+            <a href="{{ url_for('main.viewstats') }}" class="btn btn-sm btn-outline-secondary">View</a>
+          </li>
           {% endfor %}
         </ul>
         <a href="{{ url_for('main.viewstats') }}" class="btn btn-sm btn-outline-primary mt-2">View all matches</a>

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -95,17 +95,28 @@
         </thead>
         <tbody>
           {% for m in matches %}
+          {% set is_player = m.player == username %}
+          {% set opponent_name = m.opponent if is_player else m.player %}
+          {% set r = (m.result or '') | lower %}
+          {% if is_player %}
+            {% set user_result = r %}
+            {% set user_colour = m.player_colour %}
+          {% else %}
+            {% set user_colour = 'black' if m.player_colour | lower == 'white' else 'white' %}
+            {% if r == 'win' %}{% set user_result = 'loss' %}
+            {% elif r == 'loss' %}{% set user_result = 'win' %}
+            {% else %}{% set user_result = r %}{% endif %}
+          {% endif %}
           <tr>
             <td>{{ m.date_played.strftime('%Y-%m-%d') if m.date_played else '—' }}</td>
-            <td>{{ m.opponent }}</td>
-            <td class="text-capitalize">{{ m.player_colour }}</td>
+            <td>{{ opponent_name }}</td>
+            <td class="text-capitalize">{{ user_colour }}</td>
             <td>
-              {% set r = (m.result or '') | lower %}
-              {% if r == 'win' %}
+              {% if user_result == 'win' %}
                 <span class="badge bg-success">Win</span>
-              {% elif r == 'loss' %}
+              {% elif user_result == 'loss' %}
                 <span class="badge bg-danger">Loss</span>
-              {% elif r == 'draw' %}
+              {% elif user_result == 'draw' %}
                 <span class="badge bg-secondary">Draw</span>
               {% else %}
                 <span class="badge bg-warning text-dark">Pending</span>
@@ -114,11 +125,13 @@
             <td class="text-capitalize">{{ m.termination or '—' }}</td>
             <td class="text-end">
               <a href="https://lichess.org/analysis/pgn/{{ m.moves }}" target="_blank" class="btn btn-sm btn-outline-info me-1">View</a>
+              {% if is_player %}
               <a href="{{ url_for('main.edit_match', match_id=m.id) }}" class="btn btn-sm btn-outline-secondary me-1">Edit</a>
               <form method="POST" action="{{ url_for('main.delete_match', match_id=m.id) }}" class="d-inline"
                     onsubmit="return confirm('Delete this match?')">
                 <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
               </form>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}


### PR DESCRIPTION
Calendar: Event colours and result badges now show from the logged-in user's perspective. Match title always shows current user first.
Stats page: Match history now shows all matches (including those recorded by the opponent). Result and colour display correctly from the user's perspective. Edit/Delete only shown for matches the user recorded themselves.
Profile page: Recent matches now show colour played and a result badge. Identified weaknesses is now user-entered only.
Routes: Removed dynamic weaknesses computation from profile route. Calendar route reverses result/colour when user is the opponent.