### PR TITLE
Fix #175: Remove .env from git tracking

### DIFF
--- a/project/.env
+++ b/project/.env
@@ -1,1 +1,0 @@
-# SECRET_KEY = (replace with your own secure secret key)


### PR DESCRIPTION
## Summary

- Untracked `project/.env` using `git rm --cached`, no longer committed to the repository
- File still exists locally, already listed in `project/.gitignore`, so wont be re-added

## Fixes

Closes #175

## Action required after merging

Anyone running the app locally needs to create their own `project/.env` file:
```
SECRET_KEY=your-secret-key-here
```
The old secret key in the git history should be rotated and replaced with a new one.