### PR TITLE
Fix scrypt crash, null-user bugs, also Lichess board styling

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -642,6 +642,8 @@ def save_platforms():
     if 'username' not in session:
         return redirect(url_for('main.login'))
     user = User.query.filter_by(username=session['username']).first()
+    if not user:
+        return redirect(url_for('main.login'))
     user.chesscom_username = request.form.get('chesscom_username', '').strip() or None
     user.lichess_username = request.form.get('lichess_username', '').strip() or None
     user.fide_id = request.form.get('fide_id', '').strip() or None
@@ -658,6 +660,8 @@ def fetch_ratings():
         return jsonify({'error': 'Not logged in'}), 401
 
     user = User.query.filter_by(username=session['username']).first()
+    if not user:
+        return jsonify({'error': 'Not logged in'}), 401
     ratings = {}
 
     if user.chesscom_username:
@@ -1250,7 +1254,7 @@ def signup():
             flash('Email already registered!', 'error')
             return render_template('signup.html')
 
-        password_hash = generate_password_hash(password)
+        password_hash = generate_password_hash(password, method='pbkdf2:sha256')
         new_user = User(username=username, email=email, password_hash=password_hash)
         db.session.add(new_user)
         db.session.commit()
@@ -1311,7 +1315,7 @@ def forgotpassword():
                     # Update user's password
                     user = User.query.filter_by(email=session.get('resetemail')).first()
                     if user:
-                        user.password_hash = generate_password_hash(password)
+                        user.password_hash = generate_password_hash(password, method='pbkdf2:sha256')
                         try:
                             db.session.commit()
                         except Exception as e:

--- a/project/app/templates/puzzle.html
+++ b/project/app/templates/puzzle.html
@@ -31,10 +31,7 @@
   <div class="row g-4">
     <div class="col-md-6">
       <div id="board"></div>
-      <p class="mt-2 text-muted small">
-        {{ 'Black' if side_to_move == 'b' else 'White' }} to move
-        {% if last_move %}&mdash; last move: <code>{{ last_move }}</code>{% endif %}
-      </p>
+      <p class="mt-2 text-muted small">{{ 'Black' if side_to_move == 'b' else 'White' }} to move</p>
     </div>
 
     <div class="col-md-6">
@@ -75,8 +72,20 @@
   const board = Chessboard('board', {
     position: fen,
     orientation: orientation,
-    pieceTheme: 'https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/img/chesspieces/wikipedia/{piece}.png',
+    pieceTheme: 'https://lichess1.org/assets/piece/cburnett/{piece}.svg',
   });
+
+  // Highlight last-move squares exactly as Lichess does
+  const lastMove = {{ last_move | tojson }};
+  if (lastMove && lastMove.length >= 4) {
+    const squares = [lastMove.slice(0, 2), lastMove.slice(2, 4)];
+    squares.forEach(sq => {
+      const file = sq.charCodeAt(0) - 97;
+      const rank = parseInt(sq[1]) - 1;
+      const isLight = (file + rank) % 2 !== 0;
+      $(`#board .square-${sq}`).css('background-color', isLight ? '#cdd26a' : '#aaa23a');
+    });
+  }
 
   // Convert UCI moves (e.g. "f5d3") to SAN using chess.js
   function uciToSan(uciMoves, startFen) {

--- a/project/populate_database.py
+++ b/project/populate_database.py
@@ -14,10 +14,10 @@ with app.app_context():
     
     # Create sample users
     users = [
-        User(username='alice', email='alice@example.com', password_hash=generate_password_hash('password123'), is_admin=False),
-        User(username='bob', email='bob@example.com', password_hash=generate_password_hash('password123'), is_admin=False),
-        User(username='charlie', email='charlie@example.com', password_hash=generate_password_hash('password123'), is_admin=False),
-        User(username='admin', email='admin@example.com', password_hash=generate_password_hash('adminpassword123'), is_admin=True)
+        User(username='alice', email='alice@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'), is_admin=False),
+        User(username='bob', email='bob@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'), is_admin=False),
+        User(username='charlie', email='charlie@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'), is_admin=False),
+        User(username='admin', email='admin@example.com', password_hash=generate_password_hash('adminpassword123', method='pbkdf2:sha256'), is_admin=True)
     ]
 
     

--- a/project/test_app.py
+++ b/project/test_app.py
@@ -34,7 +34,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
 
     def test_signup_existing_username(self):
         # Create existing user
-        existing_user = User(username='existinguser', email='unique.email@example.com', password_hash=generate_password_hash('password123'))
+        existing_user = User(username='existinguser', email='unique.email@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(existing_user)
         db.session.commit()
         # Post to signup route with same username but different email
@@ -51,7 +51,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
 
     def test_signup_existing_email(self):
         # Create existing user
-        existing_user = User(username='uniqueusername', email='existingemail@example.com', password_hash=generate_password_hash('password123'))
+        existing_user = User(username='uniqueusername', email='existingemail@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(existing_user)
         db.session.commit()
         # Post to signup route with same email but different username
@@ -82,7 +82,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
     def test_login(self):
         # Create user to log in
         client =  self.app.test_client()
-        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123'))
+        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(user)
         db.session.commit()
         # Post to login route with correct credentials
@@ -110,7 +110,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
     def test_login_wrong_password(self):
         # Create user to log in
         client = self.app.test_client()
-        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123'))
+        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(user)
         db.session.commit()
         # Post to login route with wrong password
@@ -138,7 +138,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
     def test_logout(self):
         # Create user and log in
         client = self.app.test_client()
-        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123'))
+        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(user)
         db.session.commit()
         # Log in
@@ -164,7 +164,7 @@ class ChessMateUnitTestCase(unittest.TestCase):
     def test_adding_new_record(self):
         # Create new user
         client = self.app.test_client()
-        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123'))
+        user = User(username='testuser', email='testuser@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
         db.session.add(user)
         db.session.commit()
         


### PR DESCRIPTION
## Summary
- Fix signup/password-reset crash on Python 3.9, used `pbkdf2:sha256` instead of `scrypt` in all `generate_password_hash` calls
- Guard `/save_platforms` and `/fetch_ratings` against `AttributeError` on stale sessions
- Switch daily puzzle board to Lichess CBurnett SVG pieces with correct last-move highlight colours