### PR TITLE
Add H2H and Selenium test coverage

### DIFF
--- a/project/test_app.py
+++ b/project/test_app.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from app import create_app, db
 from app.models import User, Tournament, Match
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -195,6 +196,51 @@ class ChessMateUnitTestCase(unittest.TestCase):
         self.assertEqual(match.player_colour, 'White')
         self.assertEqual(match.result, 'Win')
         self.assertEqual(match.termination, 'Checkmate')
+
+    def test_h2h_stats(self):
+        client = self.app.test_client()
+
+        # Two users with different records against each other
+        alice = User(username='alice', email='alice@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
+        bob   = User(username='bob',   email='bob@example.com',   password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
+        db.session.add_all([alice, bob])
+        db.session.commit()
+
+        # Alice records: 2 wins and 1 loss against bob
+        db.session.add_all([
+            Match(player='alice', opponent='bob', result='win',  player_colour='white', moves='1. e4', termination='checkmate', date_played=datetime(2024, 1, 1)),
+            Match(player='alice', opponent='bob', result='win',  player_colour='black', moves='1. d4', termination='checkmate', date_played=datetime(2024, 1, 2)),
+            Match(player='alice', opponent='bob', result='loss', player_colour='white', moves='1. c4', termination='resignation', date_played=datetime(2024, 1, 3)),
+        ])
+        # Bob records: 1 win and 1 draw against alice (adds to alice's loss/draw tally)
+        db.session.add_all([
+            Match(player='bob', opponent='alice', result='win',  player_colour='black', moves='1. f4', termination='checkmate',  date_played=datetime(2024, 1, 4)),
+            Match(player='bob', opponent='alice', result='draw', player_colour='white', moves='1. g4', termination='stalemate',  date_played=datetime(2024, 1, 5)),
+        ])
+        db.session.commit()
+
+        client.post('/login', data={'username': 'alice', 'password': 'password123'})
+        resp = client.get('/h2h?opponent=bob')
+        self.assertEqual(resp.status_code, 200)
+
+        # alice: 2 wins from own records + 1 win from bob's loss = 3 wins
+        # alice: 1 loss from own records + 1 loss from bob's win = 2 losses
+        # alice: 1 draw from bob's draw = 1 draw
+        self.assertIn(b'3', resp.data)   # my_wins
+        self.assertIn(b'2', resp.data)   # opp_wins (= alice's losses)
+        self.assertIn(b'1', resp.data)   # draws
+
+        # All 5 matches should appear in match history
+        data = resp.data.decode()
+        self.assertEqual(data.count('2024-01-0'), 5)
+
+        # Verify opponent sees the mirror image
+        client.get('/logout')
+        client.post('/login', data={'username': 'bob', 'password': 'password123'})
+        resp = client.get('/h2h?opponent=alice')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.data.decode()
+        self.assertEqual(data.count('2024-01-0'), 5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/project/test_selenium_app.py
+++ b/project/test_selenium_app.py
@@ -106,10 +106,10 @@ class SeleniumTestCase(unittest.TestCase):
         submit_button.click()
 
         WebDriverWait(self.browser, 10).until(
-            EC.title_contains("Home")
+            EC.title_contains("Dashboard")
         )
 
-        self.assertIn("Home", self.browser.title)
+        self.assertIn("Dashboard", self.browser.title)
 
         # Confirm access to all dropdown menu pages
         access_page("Profile")
@@ -124,9 +124,10 @@ class SeleniumTestCase(unittest.TestCase):
         access_page("Stats")
         access_page("Calendar")
         access_page("Leaderboard")
-        access_page("Submit Issue")
+        access_page("Head-to-Head")
 
-        access_page("Home")
+        self.browser.get(localHost)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
 
         new_record_button = self.browser.find_element(By.LINK_TEXT, "Add new record")
         new_record_button.click()
@@ -167,6 +168,138 @@ class SeleniumTestCase(unittest.TestCase):
         self.assertEqual(losses_element.text, "0")
         self.assertEqual(draws_element.text, "0")
 
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _signup(self, username, email, password):
+        self.browser.get(localHost + 'signup')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Sign Up"))
+        self.browser.find_element(By.NAME, "username").send_keys(username)
+        self.browser.find_element(By.NAME, "email").send_keys(email)
+        self.browser.find_element(By.NAME, "password").send_keys(password)
+        self.browser.find_element(By.NAME, "confirm_password").send_keys(password)
+        self.browser.find_element(By.XPATH, '//button[text()="Sign Up"]').click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+
+    def _login(self, username, password):
+        self.browser.get(localHost + 'login')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.browser.find_element(By.NAME, "username").send_keys(username)
+        self.browser.find_element(By.NAME, "password").send_keys(password)
+        self.browser.find_element(By.XPATH, '//button[text()="Log in"]').click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+    # ── tests ─────────────────────────────────────────────────────────────────
+
+    def test_wrong_password_shows_error(self):
+        self._signup("testuser", "testuser@example.com", "password123")
+        self.browser.get(localHost + 'login')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.browser.find_element(By.NAME, "username").send_keys("testuser")
+        self.browser.find_element(By.NAME, "password").send_keys("wrongpassword")
+        self.browser.find_element(By.XPATH, '//button[text()="Log in"]').click()
+        WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, "alert"))
+        )
+        self.assertIn("Login", self.browser.title)
+        self.assertIn("Invalid username or password", self.browser.page_source)
+
+    def test_logout_clears_session(self):
+        self._signup("testuser", "testuser@example.com", "password123")
+        self._login("testuser", "password123")
+        self.browser.find_element(By.CSS_SELECTOR, "a.nav-link.dropdown-toggle").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.LINK_TEXT, "Logout"))
+        )
+        self.browser.find_element(By.LINK_TEXT, "Logout").click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Chessmate"))
+        # After logout, accessing a protected page should redirect to login
+        self.browser.get(localHost + 'profile')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.assertIn("Login", self.browser.title)
+
+    def test_leaderboard_shows_user(self):
+        self._signup("leaderuser", "leaderuser@example.com", "password123")
+        self._login("leaderuser", "password123")
+        self.browser.get(localHost + 'leaderboard')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Leaderboard"))
+        self.assertIn("leaderuser", self.browser.page_source)
+
+    def test_h2h_with_real_match_data(self):
+        self._signup("alice", "alice@example.com", "password123")
+        self._signup("bob", "bob@example.com", "password123")
+
+        # Alice logs a win vs bob
+        self._login("alice", "password123")
+        self.browser.get(localHost + 'new_record')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Add New Game Record"))
+        self.browser.find_element(By.NAME, "opponent").send_keys("bob")
+        self.browser.find_element(By.NAME, "result").send_keys("Win")
+        self.browser.find_element(By.NAME, "colour").send_keys("White")
+        self.browser.find_element(By.NAME, "termination").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//option[text()='Checkmate']"))
+        ).click()
+        self.browser.find_element(By.NAME, "date_played").send_keys("01-01-2025")
+        self.browser.find_element(By.NAME, "game_record").send_keys("1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7#")
+        btn = self.browser.find_element(By.XPATH, '//button[text()="Save Record"]')
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+        btn.click()
+        time.sleep(1)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+        self.browser.get(localHost + 'h2h?opponent=bob')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("alice", self.browser.page_source)
+        self.assertIn("bob", self.browser.page_source)
+        self.assertNotIn("No recorded games", self.browser.page_source)
+
+        # Bob logs a win vs alice
+        self.browser.find_element(By.CSS_SELECTOR, "a.nav-link.dropdown-toggle").click()
+        WebDriverWait(self.browser, 10).until(EC.element_to_be_clickable((By.LINK_TEXT, "Logout")))
+        self.browser.find_element(By.LINK_TEXT, "Logout").click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Chessmate"))
+
+        self._login("bob", "password123")
+        self.browser.get(localHost + 'new_record')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Add New Game Record"))
+        self.browser.find_element(By.NAME, "opponent").send_keys("alice")
+        self.browser.find_element(By.NAME, "result").send_keys("Win")
+        self.browser.find_element(By.NAME, "colour").send_keys("Black")
+        self.browser.find_element(By.NAME, "termination").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//option[text()='Resignation']"))
+        ).click()
+        self.browser.find_element(By.NAME, "date_played").send_keys("02-01-2025")
+        self.browser.find_element(By.NAME, "game_record").send_keys("1. e4 e5 2. Nf3 Nc6 3. Bb5 a6")
+        btn = self.browser.find_element(By.XPATH, '//button[text()="Save Record"]')
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+        btn.click()
+        time.sleep(1)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+        self.browser.get(localHost + 'h2h?opponent=alice')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("alice", self.browser.page_source)
+        self.assertNotIn("No recorded games", self.browser.page_source)
+
+    def test_h2h_no_games_message(self):
+        self._signup("player1", "player1@example.com", "password123")
+        self._signup("player2", "player2@example.com", "password123")
+        self._login("player1", "password123")
+        self.browser.get(localHost + 'h2h?opponent=player2')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("No recorded games", self.browser.page_source)
+
+    def test_puzzle_page_accessible(self):
+        self._signup("puzzleuser", "puzzleuser@example.com", "password123")
+        self._login("puzzleuser", "password123")
+        self.browser.get(localHost + 'puzzle')
+        WebDriverWait(self.browser, 10).until(
+            lambda d: "Daily Puzzle" in d.title or "Dashboard" in d.title
+        )
+        # Either puzzle loaded or gracefully redirected home (if lichess unreachable)
+        self.assertTrue("Daily Puzzle" in self.browser.title or "Dashboard" in self.browser.title)
 
     def test_incorrect_access_attempts(self):
         self.browser.get(localHost)


### PR DESCRIPTION
## Summary
- unit test for H2H stats with two users recording matches against each other from both perspectives
- Fix existing test_full_website: broken nav link names and title checks
- 5 new Selenium tests bringing total to 8: wrong password error, logout session clear, leaderboard display, H2H with real match data, puzzle page access
- _signup/_login helpers to reduce boilerplate across Selenium tests