### PR TITLE
Feature: advanced metrics on stats page

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import urllib.request
 from flask import Flask, render_template, request, redirect, url_for, flash, jsonify, session
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -10,6 +11,61 @@ from .blueprints import main
 from .models import User, Tournament, Match, Friendship, Queries
 from .forgot_password import reset_password_email
 from datetime import datetime
+
+# Opening lookup — ordered most-specific first so the longest match wins
+_OPENINGS = [
+    ('e4 e5 Nf3 Nc6 Bb5 a6 Ba4 Nf6 O-O', 'Ruy López — Open'),
+    ('e4 e5 Nf3 Nc6 Bb5 a6',              'Ruy López — Morphy'),
+    ('e4 e5 Nf3 Nc6 Bb5',                 'Ruy López'),
+    ('e4 e5 Nf3 Nc6 Bc4 Bc5',            'Italian — Giuoco Piano'),
+    ('e4 e5 Nf3 Nc6 Bc4 Nf6',            'Italian — Two Knights'),
+    ('e4 e5 Nf3 Nc6 Bc4',                'Italian Game'),
+    ('e4 e5 Nf3 Nc6 d4',                 'Scotch Game'),
+    ('e4 e5 f4',                          "King's Gambit"),
+    ('e4 e5 Nf3 Nf6',                    'Petrov Defence'),
+    ('e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 g6', 'Sicilian — Dragon'),
+    ('e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6', 'Sicilian — Najdorf'),
+    ('e4 c5 Nf3 Nc6 d4 cxd4 Nxd4',      'Sicilian — Classical'),
+    ('e4 c5 Nf3 e6',                     'Sicilian — Kan'),
+    ('e4 c5',                            'Sicilian Defence'),
+    ('e4 e6 d4 d5',                      'French Defence'),
+    ('e4 e6',                            'French Defence'),
+    ('e4 c6 d4 d5 Nc3 dxe4 Nxe4',       'Caro-Kann — Classical'),
+    ('e4 c6',                            'Caro-Kann'),
+    ('e4 d5',                            'Scandinavian Defence'),
+    ('e4 Nf6',                           "Alekhine's Defence"),
+    ('e4 g6',                            'Modern Defence'),
+    ('d4 Nf6 c4 g6 Nc3 d5',             'Grünfeld Defence'),
+    ('d4 Nf6 c4 g6 Nc3 Bg7 e4',         "King's Indian — Classical"),
+    ('d4 Nf6 c4 g6',                     "King's Indian Defence"),
+    ('d4 Nf6 c4 e6 Nc3 Bb4',            'Nimzo-Indian Defence'),
+    ('d4 Nf6 c4 e6 Nf3 b6',             "Queen's Indian Defence"),
+    ('d4 d5 c4 dxc4',                   "Queen's Gambit Accepted"),
+    ('d4 d5 c4 c6 Nf3 Nf6',            'Slav — Three Knights'),
+    ('d4 d5 c4 c6',                     'Slav Defence'),
+    ('d4 d5 c4 e6 Nc3 Nf6 Bg5',        "Queen's Gambit — Orthodox"),
+    ('d4 d5 c4 e6',                     "Queen's Gambit Declined"),
+    ('d4 d5 c4',                        "Queen's Gambit"),
+    ('d4 f5',                           'Dutch Defence'),
+    ('d4 d5',                           "Closed Game"),
+    ('c4 e5',                           'English — Reversed Sicilian'),
+    ('c4',                              'English Opening'),
+    ('Nf3 d5 c4',                       'Réti Opening'),
+    ('Nf3',                             'Réti / Zukertort'),
+    ('d4',                              "Queen's Pawn Game"),
+    ('e4',                              "King's Pawn Game"),
+]
+
+
+def _identify_opening(pgn):
+    # Strip move numbers (e.g. "1." "12."), annotations, and result markers
+    clean = re.sub(r'\d+\.+', '', pgn or '')
+    clean = re.sub(r'[+#!?]', '', clean)
+    clean = ' '.join(clean.split())
+    for moves, name in _OPENINGS:
+        if clean.startswith(moves):
+            return name
+    return 'Other'
 
 
 def _player_stats(username):
@@ -791,8 +847,80 @@ def viewstats():
         (Match.player == username) | (Match.opponent == username)
     ).order_by(Match.date_played.desc()).all()
 
+    # White vs black performance split
+    colour_stats = {'white': {'win': 0, 'loss': 0, 'draw': 0},
+                    'black': {'win': 0, 'loss': 0, 'draw': 0}}
+    for m in user_matches:
+        r = (m.result or '').lower()
+        if r not in ('win', 'loss', 'draw'):
+            continue
+        if m.player == username:
+            col = (m.player_colour or '').lower()
+            res = r
+        else:
+            # Match recorded by opponent — invert colour and result to get our perspective
+            col = 'black' if (m.player_colour or '').lower() == 'white' else 'white'
+            res = 'win' if r == 'loss' else ('loss' if r == 'win' else 'draw')
+        if col in colour_stats:
+            colour_stats[col][res] += 1
+
+    # Termination breakdown
+    termination_counts = {}
+    for m in user_matches:
+        if (m.result or '').lower() in ('win', 'loss', 'draw') and m.termination:
+            key = m.termination.lower()
+            termination_counts[key] = termination_counts.get(key, 0) + 1
+    top_terminations = sorted(termination_counts.items(), key=lambda x: x[1], reverse=True)[:4]
+
+    # Current streak and best win streak
+    completed = sorted(
+        [m for m in user_matches if (m.result or '').lower() in ('win', 'loss', 'draw')],
+        key=lambda m: m.date_played
+    )
+    result_seq = []
+    for m in completed:
+        r = (m.result or '').lower()
+        result_seq.append(r if m.player == username else
+                          ('win' if r == 'loss' else ('loss' if r == 'win' else 'draw')))
+
+    current_streak = streak_type = 0
+    if result_seq:
+        streak_type = result_seq[-1]
+        for r in reversed(result_seq):
+            if r == streak_type:
+                current_streak += 1
+            else:
+                break
+
+    best_win_streak = cur = 0
+    for r in result_seq:
+        cur = cur + 1 if r == 'win' else 0
+        best_win_streak = max(best_win_streak, cur)
+
+    # Opening performance — only matches the user recorded (we have their colour and moves)
+    opening_stats = {}
+    for m in Match.query.filter_by(player=username).all():
+        r = (m.result or '').lower()
+        if r not in ('win', 'loss', 'draw') or not m.moves:
+            continue
+        name = _identify_opening(m.moves)
+        if name not in opening_stats:
+            opening_stats[name] = {'win': 0, 'loss': 0, 'draw': 0}
+        opening_stats[name][r] += 1
+    opening_list = sorted(
+        [{'name': k, **v, 'total': v['win'] + v['loss'] + v['draw']}
+         for k, v in opening_stats.items()],
+        key=lambda x: x['total'], reverse=True
+    )[:6]
+
     return render_template('viewstats.html', username=username, user=user, stats=stats,
-                           matches=my_matches, elo_history=elo_history)
+                           matches=my_matches, elo_history=elo_history,
+                           colour_stats=colour_stats,
+                           top_terminations=top_terminations,
+                           current_streak=current_streak,
+                           streak_type=streak_type,
+                           best_win_streak=best_win_streak,
+                           opening_list=opening_list)
 
 
 # Calendar page — displays all the user's matches as FullCalendar events, colour-coded by result

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -54,15 +54,126 @@
 
   <div class="card stat-card mt-5 p-4">
     <h5 class="mb-4">Advanced Metrics</h5>
-    <div class="d-flex flex-wrap gap-3">
-      <button class="btn btn-outline-primary btn-custom" disabled>Accuracy</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Blunders per Game</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Average Move Time</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Opening Performance</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Endgame Strength</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Tactical Vision</button>
+    <div class="row g-3">
+
+      <!-- White vs Black -->
+      <div class="col-md-4">
+        <div class="card p-3 h-100">
+          <h6 class="mb-3">Colour Performance</h6>
+          {% for col in ['white', 'black'] %}
+          {% set cs = colour_stats[col] %}
+          {% set total = cs.win + cs.loss + cs.draw %}
+          <div class="mb-2">
+            <div class="d-flex justify-content-between small mb-1">
+              <span class="text-capitalize fw-semibold">{{ col }}</span>
+              <span class="text-muted">{{ cs.win }}W {{ cs.loss }}L {{ cs.draw }}D</span>
+            </div>
+            {% if total > 0 %}
+            <div class="progress" style="height:8px;">
+              <div class="progress-bar bg-success" style="width:{{ (cs.win/total*100)|round }}%"></div>
+              <div class="progress-bar bg-secondary" style="width:{{ (cs.draw/total*100)|round }}%"></div>
+              <div class="progress-bar bg-danger" style="width:{{ (cs.loss/total*100)|round }}%"></div>
+            </div>
+            {% else %}
+            <div class="text-muted small">No games</div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <!-- Termination breakdown -->
+      <div class="col-md-4">
+        <div class="card p-3 h-100">
+          <h6 class="mb-3">How Games End</h6>
+          {% if top_terminations %}
+            {% set total_t = top_terminations | sum(attribute=1) %}
+            {% for name, count in top_terminations %}
+            <div class="mb-2">
+              <div class="d-flex justify-content-between small mb-1">
+                <span class="text-capitalize">{{ name }}</span>
+                <span class="text-muted">{{ count }}</span>
+              </div>
+              <div class="progress" style="height:6px;">
+                <div class="progress-bar bg-primary" style="width:{{ (count/total_t*100)|round }}%"></div>
+              </div>
+            </div>
+            {% endfor %}
+          {% else %}
+            <p class="text-muted small mb-0">No data yet</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Streaks -->
+      <div class="col-md-4">
+        <div class="card p-3 h-100">
+          <h6 class="mb-3">Streaks</h6>
+          <div class="mb-3">
+            <div class="small text-muted mb-1">Current streak</div>
+            {% if current_streak > 0 %}
+            <span class="fs-4 fw-bold text-{{ 'success' if streak_type == 'win' else 'danger' if streak_type == 'loss' else 'secondary' }}">
+              {{ current_streak }}
+            </span>
+            <span class="small text-muted ms-1 text-capitalize">{{ streak_type }}{{ 's' if current_streak != 1 }}</span>
+            {% else %}
+            <span class="text-muted small">No matches yet</span>
+            {% endif %}
+          </div>
+          <div>
+            <div class="small text-muted mb-1">Best win streak</div>
+            <span class="fs-4 fw-bold text-success">{{ best_win_streak }}</span>
+          </div>
+        </div>
+      </div>
+
     </div>
-    <small class="text-muted mt-3 d-block">These buttons are not clickable yet</small>
+      <!-- Opening performance -->
+      <div class="col-12 mt-2">
+        <div class="card p-3">
+          <h6 class="mb-3">Opening Performance</h6>
+          {% if opening_list %}
+          <div class="table-responsive">
+            <table class="table table-sm mb-0">
+              <thead>
+                <tr>
+                  <th>Opening</th>
+                  <th class="text-center">Games</th>
+                  <th class="text-center text-success">W</th>
+                  <th class="text-center text-danger">L</th>
+                  <th class="text-center">D</th>
+                  <th>Win rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for o in opening_list %}
+                {% set wr = (o.win / o.total * 100) | round | int %}
+                <tr>
+                  <td>{{ o.name }}</td>
+                  <td class="text-center">{{ o.total }}</td>
+                  <td class="text-center text-success">{{ o.win }}</td>
+                  <td class="text-center text-danger">{{ o.loss }}</td>
+                  <td class="text-center">{{ o.draw }}</td>
+                  <td style="min-width:120px;">
+                    <div class="d-flex align-items-center gap-2">
+                      <div class="progress flex-grow-1" style="height:6px;">
+                        <div class="progress-bar bg-success" style="width:{{ wr }}%"></div>
+                      </div>
+                      <small class="text-muted">{{ wr }}%</small>
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <p class="text-muted small mb-0">Record some matches to see opening stats.</p>
+          {% endif %}
+        </div>
+      </div>
+
+    </div>
   </div>
 
   <div class="card card-ui mt-4 p-3">

--- a/project/test_app.py
+++ b/project/test_app.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from app import create_app, db
 from app.models import User, Tournament, Match
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -195,6 +196,51 @@ class ChessMateUnitTestCase(unittest.TestCase):
         self.assertEqual(match.player_colour, 'White')
         self.assertEqual(match.result, 'Win')
         self.assertEqual(match.termination, 'Checkmate')
+
+    def test_h2h_stats(self):
+        client = self.app.test_client()
+
+        # Two users with different records against each other
+        alice = User(username='alice', email='alice@example.com', password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
+        bob   = User(username='bob',   email='bob@example.com',   password_hash=generate_password_hash('password123', method='pbkdf2:sha256'))
+        db.session.add_all([alice, bob])
+        db.session.commit()
+
+        # Alice records: 2 wins and 1 loss against bob
+        db.session.add_all([
+            Match(player='alice', opponent='bob', result='win',  player_colour='white', moves='1. e4', termination='checkmate', date_played=datetime(2024, 1, 1)),
+            Match(player='alice', opponent='bob', result='win',  player_colour='black', moves='1. d4', termination='checkmate', date_played=datetime(2024, 1, 2)),
+            Match(player='alice', opponent='bob', result='loss', player_colour='white', moves='1. c4', termination='resignation', date_played=datetime(2024, 1, 3)),
+        ])
+        # Bob records: 1 win and 1 draw against alice (adds to alice's loss/draw tally)
+        db.session.add_all([
+            Match(player='bob', opponent='alice', result='win',  player_colour='black', moves='1. f4', termination='checkmate',  date_played=datetime(2024, 1, 4)),
+            Match(player='bob', opponent='alice', result='draw', player_colour='white', moves='1. g4', termination='stalemate',  date_played=datetime(2024, 1, 5)),
+        ])
+        db.session.commit()
+
+        client.post('/login', data={'username': 'alice', 'password': 'password123'})
+        resp = client.get('/h2h?opponent=bob')
+        self.assertEqual(resp.status_code, 200)
+
+        # alice: 2 wins from own records + 1 win from bob's loss = 3 wins
+        # alice: 1 loss from own records + 1 loss from bob's win = 2 losses
+        # alice: 1 draw from bob's draw = 1 draw
+        self.assertIn(b'3', resp.data)   # my_wins
+        self.assertIn(b'2', resp.data)   # opp_wins (= alice's losses)
+        self.assertIn(b'1', resp.data)   # draws
+
+        # All 5 matches should appear in match history
+        data = resp.data.decode()
+        self.assertEqual(data.count('2024-01-0'), 5)
+
+        # Verify opponent sees the mirror image
+        client.get('/logout')
+        client.post('/login', data={'username': 'bob', 'password': 'password123'})
+        resp = client.get('/h2h?opponent=alice')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.data.decode()
+        self.assertEqual(data.count('2024-01-0'), 5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/project/test_selenium_app.py
+++ b/project/test_selenium_app.py
@@ -106,10 +106,10 @@ class SeleniumTestCase(unittest.TestCase):
         submit_button.click()
 
         WebDriverWait(self.browser, 10).until(
-            EC.title_contains("Home")
+            EC.title_contains("Dashboard")
         )
 
-        self.assertIn("Home", self.browser.title)
+        self.assertIn("Dashboard", self.browser.title)
 
         # Confirm access to all dropdown menu pages
         access_page("Profile")
@@ -124,9 +124,10 @@ class SeleniumTestCase(unittest.TestCase):
         access_page("Stats")
         access_page("Calendar")
         access_page("Leaderboard")
-        access_page("Submit Issue")
+        access_page("Head-to-Head")
 
-        access_page("Home")
+        self.browser.get(localHost)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
 
         new_record_button = self.browser.find_element(By.LINK_TEXT, "Add new record")
         new_record_button.click()
@@ -167,6 +168,138 @@ class SeleniumTestCase(unittest.TestCase):
         self.assertEqual(losses_element.text, "0")
         self.assertEqual(draws_element.text, "0")
 
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _signup(self, username, email, password):
+        self.browser.get(localHost + 'signup')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Sign Up"))
+        self.browser.find_element(By.NAME, "username").send_keys(username)
+        self.browser.find_element(By.NAME, "email").send_keys(email)
+        self.browser.find_element(By.NAME, "password").send_keys(password)
+        self.browser.find_element(By.NAME, "confirm_password").send_keys(password)
+        self.browser.find_element(By.XPATH, '//button[text()="Sign Up"]').click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+
+    def _login(self, username, password):
+        self.browser.get(localHost + 'login')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.browser.find_element(By.NAME, "username").send_keys(username)
+        self.browser.find_element(By.NAME, "password").send_keys(password)
+        self.browser.find_element(By.XPATH, '//button[text()="Log in"]').click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+    # ── tests ─────────────────────────────────────────────────────────────────
+
+    def test_wrong_password_shows_error(self):
+        self._signup("testuser", "testuser@example.com", "password123")
+        self.browser.get(localHost + 'login')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.browser.find_element(By.NAME, "username").send_keys("testuser")
+        self.browser.find_element(By.NAME, "password").send_keys("wrongpassword")
+        self.browser.find_element(By.XPATH, '//button[text()="Log in"]').click()
+        WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, "alert"))
+        )
+        self.assertIn("Login", self.browser.title)
+        self.assertIn("Invalid username or password", self.browser.page_source)
+
+    def test_logout_clears_session(self):
+        self._signup("testuser", "testuser@example.com", "password123")
+        self._login("testuser", "password123")
+        self.browser.find_element(By.CSS_SELECTOR, "a.nav-link.dropdown-toggle").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.LINK_TEXT, "Logout"))
+        )
+        self.browser.find_element(By.LINK_TEXT, "Logout").click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Chessmate"))
+        # After logout, accessing a protected page should redirect to login
+        self.browser.get(localHost + 'profile')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Login"))
+        self.assertIn("Login", self.browser.title)
+
+    def test_leaderboard_shows_user(self):
+        self._signup("leaderuser", "leaderuser@example.com", "password123")
+        self._login("leaderuser", "password123")
+        self.browser.get(localHost + 'leaderboard')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Leaderboard"))
+        self.assertIn("leaderuser", self.browser.page_source)
+
+    def test_h2h_with_real_match_data(self):
+        self._signup("alice", "alice@example.com", "password123")
+        self._signup("bob", "bob@example.com", "password123")
+
+        # Alice logs a win vs bob
+        self._login("alice", "password123")
+        self.browser.get(localHost + 'new_record')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Add New Game Record"))
+        self.browser.find_element(By.NAME, "opponent").send_keys("bob")
+        self.browser.find_element(By.NAME, "result").send_keys("Win")
+        self.browser.find_element(By.NAME, "colour").send_keys("White")
+        self.browser.find_element(By.NAME, "termination").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//option[text()='Checkmate']"))
+        ).click()
+        self.browser.find_element(By.NAME, "date_played").send_keys("01-01-2025")
+        self.browser.find_element(By.NAME, "game_record").send_keys("1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7#")
+        btn = self.browser.find_element(By.XPATH, '//button[text()="Save Record"]')
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+        btn.click()
+        time.sleep(1)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+        self.browser.get(localHost + 'h2h?opponent=bob')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("alice", self.browser.page_source)
+        self.assertIn("bob", self.browser.page_source)
+        self.assertNotIn("No recorded games", self.browser.page_source)
+
+        # Bob logs a win vs alice
+        self.browser.find_element(By.CSS_SELECTOR, "a.nav-link.dropdown-toggle").click()
+        WebDriverWait(self.browser, 10).until(EC.element_to_be_clickable((By.LINK_TEXT, "Logout")))
+        self.browser.find_element(By.LINK_TEXT, "Logout").click()
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Chessmate"))
+
+        self._login("bob", "password123")
+        self.browser.get(localHost + 'new_record')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Add New Game Record"))
+        self.browser.find_element(By.NAME, "opponent").send_keys("alice")
+        self.browser.find_element(By.NAME, "result").send_keys("Win")
+        self.browser.find_element(By.NAME, "colour").send_keys("Black")
+        self.browser.find_element(By.NAME, "termination").click()
+        WebDriverWait(self.browser, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//option[text()='Resignation']"))
+        ).click()
+        self.browser.find_element(By.NAME, "date_played").send_keys("02-01-2025")
+        self.browser.find_element(By.NAME, "game_record").send_keys("1. e4 e5 2. Nf3 Nc6 3. Bb5 a6")
+        btn = self.browser.find_element(By.XPATH, '//button[text()="Save Record"]')
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+        btn.click()
+        time.sleep(1)
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Dashboard"))
+
+        self.browser.get(localHost + 'h2h?opponent=alice')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("alice", self.browser.page_source)
+        self.assertNotIn("No recorded games", self.browser.page_source)
+
+    def test_h2h_no_games_message(self):
+        self._signup("player1", "player1@example.com", "password123")
+        self._signup("player2", "player2@example.com", "password123")
+        self._login("player1", "password123")
+        self.browser.get(localHost + 'h2h?opponent=player2')
+        WebDriverWait(self.browser, 10).until(EC.title_contains("Head-to-Head"))
+        self.assertIn("No recorded games", self.browser.page_source)
+
+    def test_puzzle_page_accessible(self):
+        self._signup("puzzleuser", "puzzleuser@example.com", "password123")
+        self._login("puzzleuser", "password123")
+        self.browser.get(localHost + 'puzzle')
+        WebDriverWait(self.browser, 10).until(
+            lambda d: "Daily Puzzle" in d.title or "Dashboard" in d.title
+        )
+        # Either puzzle loaded or gracefully redirected home (if lichess unreachable)
+        self.assertTrue("Daily Puzzle" in self.browser.title or "Dashboard" in self.browser.title)
 
     def test_incorrect_access_attempts(self):
         self.browser.get(localHost)


### PR DESCRIPTION
## Summary
- Colour performance: win/loss/draw breakdown split by white and black
- Termination breakdown: bar chart of how games end (checkmate, resignation, stalemate etc.)
- Streak tracking: current streak with type and best win streak
- Opening performance: table of W/L/D and win rate per opening, matched from a 39-opening lookup against stored PGN moves
- Removed disabled placeholder buttons for engine-dependent metrics (accuracy, blunders) those would need Stockfish to be installed