### PR TITLE
Feature: advanced metrics on stats page

### DIFF
--- a/project/app/routes.py
+++ b/project/app/routes.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import urllib.request
 from flask import Flask, render_template, request, redirect, url_for, flash, jsonify, session
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -10,6 +11,61 @@ from .blueprints import main
 from .models import User, Tournament, Match, Friendship, Queries
 from .forgot_password import reset_password_email
 from datetime import datetime
+
+# Opening lookup — ordered most-specific first so the longest match wins
+_OPENINGS = [
+    ('e4 e5 Nf3 Nc6 Bb5 a6 Ba4 Nf6 O-O', 'Ruy López — Open'),
+    ('e4 e5 Nf3 Nc6 Bb5 a6',              'Ruy López — Morphy'),
+    ('e4 e5 Nf3 Nc6 Bb5',                 'Ruy López'),
+    ('e4 e5 Nf3 Nc6 Bc4 Bc5',            'Italian — Giuoco Piano'),
+    ('e4 e5 Nf3 Nc6 Bc4 Nf6',            'Italian — Two Knights'),
+    ('e4 e5 Nf3 Nc6 Bc4',                'Italian Game'),
+    ('e4 e5 Nf3 Nc6 d4',                 'Scotch Game'),
+    ('e4 e5 f4',                          "King's Gambit"),
+    ('e4 e5 Nf3 Nf6',                    'Petrov Defence'),
+    ('e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 g6', 'Sicilian — Dragon'),
+    ('e4 c5 Nf3 d6 d4 cxd4 Nxd4 Nf6 Nc3 a6', 'Sicilian — Najdorf'),
+    ('e4 c5 Nf3 Nc6 d4 cxd4 Nxd4',      'Sicilian — Classical'),
+    ('e4 c5 Nf3 e6',                     'Sicilian — Kan'),
+    ('e4 c5',                            'Sicilian Defence'),
+    ('e4 e6 d4 d5',                      'French Defence'),
+    ('e4 e6',                            'French Defence'),
+    ('e4 c6 d4 d5 Nc3 dxe4 Nxe4',       'Caro-Kann — Classical'),
+    ('e4 c6',                            'Caro-Kann'),
+    ('e4 d5',                            'Scandinavian Defence'),
+    ('e4 Nf6',                           "Alekhine's Defence"),
+    ('e4 g6',                            'Modern Defence'),
+    ('d4 Nf6 c4 g6 Nc3 d5',             'Grünfeld Defence'),
+    ('d4 Nf6 c4 g6 Nc3 Bg7 e4',         "King's Indian — Classical"),
+    ('d4 Nf6 c4 g6',                     "King's Indian Defence"),
+    ('d4 Nf6 c4 e6 Nc3 Bb4',            'Nimzo-Indian Defence'),
+    ('d4 Nf6 c4 e6 Nf3 b6',             "Queen's Indian Defence"),
+    ('d4 d5 c4 dxc4',                   "Queen's Gambit Accepted"),
+    ('d4 d5 c4 c6 Nf3 Nf6',            'Slav — Three Knights'),
+    ('d4 d5 c4 c6',                     'Slav Defence'),
+    ('d4 d5 c4 e6 Nc3 Nf6 Bg5',        "Queen's Gambit — Orthodox"),
+    ('d4 d5 c4 e6',                     "Queen's Gambit Declined"),
+    ('d4 d5 c4',                        "Queen's Gambit"),
+    ('d4 f5',                           'Dutch Defence'),
+    ('d4 d5',                           "Closed Game"),
+    ('c4 e5',                           'English — Reversed Sicilian'),
+    ('c4',                              'English Opening'),
+    ('Nf3 d5 c4',                       'Réti Opening'),
+    ('Nf3',                             'Réti / Zukertort'),
+    ('d4',                              "Queen's Pawn Game"),
+    ('e4',                              "King's Pawn Game"),
+]
+
+
+def _identify_opening(pgn):
+    # Strip move numbers (e.g. "1." "12."), annotations, and result markers
+    clean = re.sub(r'\d+\.+', '', pgn or '')
+    clean = re.sub(r'[+#!?]', '', clean)
+    clean = ' '.join(clean.split())
+    for moves, name in _OPENINGS:
+        if clean.startswith(moves):
+            return name
+    return 'Other'
 
 
 def _player_stats(username):
@@ -791,8 +847,82 @@ def viewstats():
         (Match.player == username) | (Match.opponent == username)
     ).order_by(Match.date_played.desc()).all()
 
+    # White vs black performance split
+    colour_stats = {'white': {'win': 0, 'loss': 0, 'draw': 0},
+                    'black': {'win': 0, 'loss': 0, 'draw': 0}}
+    for m in user_matches:
+        r = (m.result or '').lower()
+        if r not in ('win', 'loss', 'draw'):
+            continue
+        if m.player == username:
+            col = (m.player_colour or '').lower()
+            res = r
+        else:
+            col = 'black' if (m.player_colour or '').lower() == 'white' else 'white'
+            res = 'win' if r == 'loss' else ('loss' if r == 'win' else 'draw')
+        if col in colour_stats:
+            colour_stats[col][res] += 1
+
+    # Top termination types
+    term_counts = {}
+    for m in user_matches:
+        t = (m.termination or '').strip().lower()
+        if t and t != 'upcoming':
+            term_counts[t] = term_counts.get(t, 0) + 1
+    top_terminations = sorted(term_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+
+    # Current streak and best win streak
+    current_streak = 0
+    streak_type = None
+    best_win_streak = 0
+    temp_win_streak = 0
+    for m in reversed(sorted_matches):
+        r = (m.result or '').lower()
+        actual = r if m.player == username else ('win' if r == 'loss' else ('loss' if r == 'win' else 'draw'))
+        if streak_type is None:
+            streak_type = actual
+            current_streak = 1
+        elif actual == streak_type:
+            current_streak += 1
+        else:
+            break
+        if actual == 'win':
+            temp_win_streak += 1
+            best_win_streak = max(best_win_streak, temp_win_streak)
+        else:
+            temp_win_streak = 0
+
+    # Opening performance table
+    opening_map = {}
+    for m in user_matches:
+        r = (m.result or '').lower()
+        if r not in ('win', 'loss', 'draw'):
+            continue
+        name = _identify_opening(m.moves)
+        actual = r if m.player == username else ('win' if r == 'loss' else ('loss' if r == 'win' else 'draw'))
+        if name not in opening_map:
+            opening_map[name] = {'win': 0, 'loss': 0, 'draw': 0}
+        opening_map[name][actual] += 1
+    opening_list = []
+    for name, counts in sorted(opening_map.items(), key=lambda x: sum(x[1].values()), reverse=True)[:8]:
+        total = counts['win'] + counts['loss'] + counts['draw']
+        opening_list.append({
+            'name': name,
+            'win': counts['win'],
+            'loss': counts['loss'],
+            'draw': counts['draw'],
+            'total': total,
+            'win_rate': round(counts['win'] / total * 100) if total else 0
+        })
+
     return render_template('viewstats.html', username=username, user=user, stats=stats,
-                           matches=my_matches, elo_history=elo_history)
+                           matches=my_matches, elo_history=elo_history,
+                           colour_stats=colour_stats,
+                           top_terminations=top_terminations,
+                           current_streak=current_streak,
+                           streak_type=streak_type,
+                           best_win_streak=best_win_streak,
+                           opening_list=opening_list)
 
 
 # Calendar page — displays all the user's matches as FullCalendar events, colour-coded by result

--- a/project/app/templates/viewstats.html
+++ b/project/app/templates/viewstats.html
@@ -52,17 +52,87 @@
     <svg id="eloChart" viewBox="0 0 500 150" style="width:100%;display:block;"></svg>
   </div>
 
+  <!-- Colour Performance -->
   <div class="card stat-card mt-5 p-4">
-    <h5 class="mb-4">Advanced Metrics</h5>
-    <div class="d-flex flex-wrap gap-3">
-      <button class="btn btn-outline-primary btn-custom" disabled>Accuracy</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Blunders per Game</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Average Move Time</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Opening Performance</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Endgame Strength</button>
-      <button class="btn btn-outline-primary btn-custom" disabled>Tactical Vision</button>
+    <h5 class="mb-3">Colour Performance</h5>
+    <div class="row g-3">
+      {% for colour in ['white', 'black'] %}
+      {% set cs = colour_stats[colour] %}
+      {% set total = cs.win + cs.loss + cs.draw %}
+      <div class="col-md-6">
+        <h6 class="text-capitalize">{{ colour }}</h6>
+        {% if total > 0 %}
+        <div class="progress mb-1" style="height:18px;">
+          <div class="progress-bar bg-success" style="width:{{ (cs.win/total*100)|round }}%">{{ cs.win }}W</div>
+          <div class="progress-bar bg-danger" style="width:{{ (cs.loss/total*100)|round }}%">{{ cs.loss }}L</div>
+          <div class="progress-bar bg-secondary" style="width:{{ (cs.draw/total*100)|round }}%">{{ cs.draw }}D</div>
+        </div>
+        <small class="text-muted">{{ total }} games · {{ (cs.win/total*100)|round|int }}% win rate</small>
+        {% else %}
+        <small class="text-muted">No games recorded as {{ colour }}</small>
+        {% endif %}
+      </div>
+      {% endfor %}
     </div>
-    <small class="text-muted mt-3 d-block">These buttons are not clickable yet</small>
+  </div>
+
+  <!-- How Games End -->
+  <div class="card stat-card mt-4 p-4">
+    <h5 class="mb-3">How Games End</h5>
+    {% if top_terminations %}
+    {% set max_term = top_terminations[0][1] %}
+    {% for term, count in top_terminations %}
+    <div class="d-flex align-items-center mb-2">
+      <span class="text-capitalize me-2" style="min-width:130px;">{{ term }}</span>
+      <div class="progress flex-grow-1 me-2" style="height:14px;">
+        <div class="progress-bar bg-primary" style="width:{{ (count/max_term*100)|round }}%;"></div>
+      </div>
+      <small>{{ count }}</small>
+    </div>
+    {% endfor %}
+    {% else %}
+    <small class="text-muted">No completed games yet.</small>
+    {% endif %}
+  </div>
+
+  <!-- Streaks -->
+  <div class="card stat-card mt-4 p-4">
+    <h5 class="mb-3">Streaks</h5>
+    <div class="row g-3">
+      <div class="col-6 text-center">
+        <div class="fs-1 fw-bold">{{ current_streak }}</div>
+        <div class="text-muted small">Current {{ streak_type or '—' }} streak</div>
+      </div>
+      <div class="col-6 text-center">
+        <div class="fs-1 fw-bold">{{ best_win_streak }}</div>
+        <div class="text-muted small">Best win streak</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Opening Performance -->
+  <div class="card stat-card mt-4 p-4">
+    <h5 class="mb-3">Opening Performance</h5>
+    {% if opening_list %}
+    <div style="overflow-x:auto;">
+      <table class="table table-sm table-hover mb-0">
+        <thead><tr><th>Opening</th><th>W</th><th>L</th><th>D</th><th>Win %</th></tr></thead>
+        <tbody>
+        {% for o in opening_list %}
+        <tr>
+          <td>{{ o.name }}</td>
+          <td class="text-success">{{ o.win }}</td>
+          <td class="text-danger">{{ o.loss }}</td>
+          <td class="text-secondary">{{ o.draw }}</td>
+          <td>{{ o.win_rate }}%</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <small class="text-muted">No completed games yet.</small>
+    {% endif %}
   </div>
 
   <div class="card card-ui mt-4 p-3">


### PR DESCRIPTION
## Summary
- Add `_OPENINGS` lookup table (39 openings, most-specific first) and `_identify_opening()` PGN parser
- Compute colour split (white/black W/L/D), top terminations, streak tracking, and opening performance per viewstats session
- Replace 6 disabled placeholder buttons with 4 live metric cards: Colour Performance (progress bars), How Games End (termination breakdown), Streaks (current + best win streak), Opening Performance (W/L/D table with win rate)

## Test plan
- [ ] Log in with seeded data and visit /viewstats — confirm all 4 metric sections render with real values
- [ ] Verify empty-state messages show when user has no completed games