### PR TITLE
Fix unresolved conflict marker in .header.html

### DIFF
--- a/project/app/templates/.header.html
+++ b/project/app/templates/.header.html
@@ -76,12 +76,9 @@
                 <li><a class="dropdown-item" href="{{ url_for('main.view_queries') }}"><i class="bi bi-bar-chart me-2"></i>View queries</a></li>
                 <li><hr class="dropdown-divider"></li>
               {% endif %}
-<<<<<<< HEAD
-=======
 
               <li><hr class="dropdown-divider"></li>
 
->>>>>>> 101a1209452cbf0888954b134f3f2c8317f504e1
               <li>
                 <button class="dropdown-item" onclick="toggleTheme()">
                   <i class="bi bi-moon me-2" id="theme-icon"></i><span id="theme-label">Dark Mode</span>


### PR DESCRIPTION
## Summary
- Removes leftover git conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>>`) from `.header.html` that were causing them to render visibly in the navbar dropdown
- Keeps the divider before the Dark Mode button (the correct resolution)

## Test plan
- [ ] Navbar dropdown shows correctly with no conflict marker text
- [ ] Divider appears between admin links and Dark Mode button